### PR TITLE
[NO-TASK]: Social Media Updates

### DIFF
--- a/socialmedia/socialmedia.helper.ts
+++ b/socialmedia/socialmedia.helper.ts
@@ -18,5 +18,12 @@ export function createRefCodeLabelLink(frontendCode: string): string {
 	}
 
 	const refCode = createRefCode(frontendCode);
-	return refCode ? `[${refCode}](https://app.deuro.com?ref=${refCode})` : '';
+	if (!refCode) return '';
+	
+	// Special case for Cake Wallet
+	if (refCode === 'Cake Wallet') {
+		return `[${refCode}](https://cakewallet.com/)`;
+	}
+	
+	return `[${refCode}](https://app.deuro.com?ref=${refCode})`;
 }

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -211,6 +211,7 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 	}
 
 	async doSendSavingUpdates(savingSaved: FrontendCodeSavingsQuery): Promise<void> {
+		if (BigInt(savingSaved.amount) === 0n) return;
 		const messageInfo = SavingUpdateMessage(savingSaved);
 		this.sendMessageAll(messageInfo[0], messageInfo[1]);
 	}
@@ -221,11 +222,13 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 	}
 
 	async doSendTradeUpdates(trade: TradeQuery, depsMarketCap: number, totalShares: bigint): Promise<void> {
+		if (BigInt(trade.amount) === 0n) return;
 		const messageInfo = TradeMessage(trade, depsMarketCap, totalShares);
 		this.sendMessageAll(messageInfo[0], messageInfo[1]);
 	}
 
 	async doSendBridgeUpdates(bridge: StablecoinBridgeQuery, stablecoin: string): Promise<void> {
+		if (BigInt(bridge.amount) === 0n) return;
 		const messageInfo = StablecoinBridgeMessage(bridge, stablecoin);
 		this.sendMessageAll(messageInfo[0], messageInfo[1]);
 	}

--- a/socialmedia/twitter/messages/SavingUpdate.message.ts
+++ b/socialmedia/twitter/messages/SavingUpdate.message.ts
@@ -6,7 +6,8 @@ import { formatUnits } from 'viem';
 
 export function SavingUpdateMessage(saving: FrontendCodeSavingsQuery): string[] {
 	const refCode = createRefCode(saving.frontendCode);
-	const usedRef = refCode ? `🪢 used Ref: ${refCode}` : '';
+	const displayRef = refCode === 'Cake Wallet' ? '@cakewallet' : refCode;
+	const usedRef = displayRef ? `🪢 used Ref: ${displayRef}` : '';
 
 	const message = `
 New dEURO Savings!

--- a/socialmedia/twitter/messages/Trade.message.ts
+++ b/socialmedia/twitter/messages/Trade.message.ts
@@ -6,7 +6,8 @@ import { formatUnits } from 'viem';
 
 export function TradeMessage(trade: TradeQuery, marketCap: number, totalShares: bigint): string[] {
 	const refCode = createRefCode(trade.frontendCode);
-	const usedRef = refCode ? `🪢 used Ref: ${refCode}` : '';
+	const displayRef = refCode === 'Cake Wallet' ? '@cakewallet' : refCode;
+	const usedRef = displayRef ? `🪢 used Ref: ${displayRef}` : '';
 
 	const actualShares = Number(formatUnits(totalShares, 18));
 	const sharesBefore = actualShares - Number(formatUnits(BigInt(trade.shares), 18));

--- a/socialmedia/twitter/twitter.service.ts
+++ b/socialmedia/twitter/twitter.service.ts
@@ -41,6 +41,7 @@ export class TwitterService implements OnModuleInit, SocialMediaFct {
 	}
 
 	async doSendSavingUpdates(savingSaved: FrontendCodeSavingsQuery): Promise<void> {
+		if (BigInt(savingSaved.amount) === 0n) return;
 		const messageInfo = SavingUpdateMessage(savingSaved);
 		await this.sendPost(messageInfo[0], messageInfo[1]);
 	}
@@ -51,11 +52,13 @@ export class TwitterService implements OnModuleInit, SocialMediaFct {
 	}
 
 	async doSendTradeUpdates(trade: TradeQuery, depsMarketCap: number, totalShares: bigint): Promise<void> {
+		if (BigInt(trade.amount) === 0n) return;
 		const messageInfo = TradeMessage(trade, depsMarketCap, totalShares);
 		await this.sendPost(messageInfo[0], messageInfo[1]);
 	}
 
 	async doSendBridgeUpdates(bridge: StablecoinBridgeQuery, stablecoin: string): Promise<void> {
+		if (BigInt(bridge.amount) === 0n) return;
 		const messageInfo = StablecoinBridgeMessage(bridge, stablecoin);
 		this.sendPost(messageInfo[0], messageInfo[1]);
 	}


### PR DESCRIPTION
## Summary
- Skip social media posts when amount is zero for Savings, Trades and Bridge updates
- Add special handling for Cake Wallet references:
  - Telegram: Links to https://cakewallet.com/
  - Twitter: Displays @cakewallet mention

## Changes
- Added amount = 0 checks in Telegram and Twitter services
- Special case for "Cake Wallet" in `createRefCodeLabelLink()` helper
- Twitter messages now show @cakewallet instead of "Cake Wallet"

## Test plan
- [x] Code review completed
- [ ] Deploy to production
- [ ] Verify zero amount transactions don't post
- [ ] Verify Cake Wallet shows as @cakewallet on Twitter
- [ ] Verify Cake Wallet links to cakewallet.com on Telegram