### PR TITLE
feat: Add endpoint for total savings users count

### DIFF
--- a/savings/savings.core.controller.ts
+++ b/savings/savings.core.controller.ts
@@ -25,6 +25,14 @@ export class SavingsCoreController {
 		return this.savings.getSavingsUserLeaderboard();
 	}
 
+	@Get('info/total-users')
+	@ApiResponse({
+		description: 'returns the total number of unique savings users.',
+	})
+	async getTotalUsers(): Promise<{ totalUsers: number }> {
+		return await this.savings.getTotalSavingsUsers();
+	}
+
 	@Get('user/:address')
 	@ApiResponse({
 		description: 'returns the latest user table history or recent entries from all users',

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -86,6 +86,29 @@ export class SavingsCoreService {
 		return this.fetchedSavingsUserLeaderboard;
 	}
 
+	async getTotalSavingsUsers(): Promise<{ totalUsers: number }> {
+		this.logger.debug('Getting total savings users count');
+		
+		// Query all unique users who have ever interacted with savings
+		const data = await PONDER_CLIENT.query({
+			fetchPolicy: 'no-cache',
+			query: gql`
+				{
+					savingsUserLeaderboards {
+						items {
+							id
+						}
+					}
+				}
+			`,
+		});
+
+		const totalUsers = data?.data?.savingsUserLeaderboards?.items?.length ?? 0;
+		
+		this.logger.debug(`Total savings users: ${totalUsers}`);
+		return { totalUsers };
+	}
+
 	async getUserTables(userAddress: Address, limit: number = 15): Promise<ApiSavingsUserTable> {
 		const user: Address = userAddress == zeroAddress ? zeroAddress : (userAddress.toLowerCase() as Address);
 		const savedFetched = await PONDER_CLIENT.query({

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -89,20 +89,13 @@ export class SavingsCoreService {
 	async getTotalSavingsUsers(): Promise<{ totalUsers: number }> {
 		this.logger.debug('Getting total savings users count');
 		
-		// Option 1: If we have cached leaderboard data, use it (most efficient)
-		if (this.fetchedSavingsUserLeaderboard.length > 0) {
-			const totalUsers = this.fetchedSavingsUserLeaderboard.length;
-			this.logger.debug(`Total savings users from cache: ${totalUsers}`);
-			return { totalUsers };
-		}
-		
-		// Option 2: Query only the IDs with high limit (fallback)
-		// This is still more efficient than loading all fields
+		// Always query fresh data to ensure accuracy
+		// Only fetch IDs to minimize data transfer
 		const data = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`
 				{
-					savingsUserLeaderboards(limit: 10000) {
+					savingsUserLeaderboards(limit: 100000) {
 						items {
 							id
 						}
@@ -113,7 +106,7 @@ export class SavingsCoreService {
 
 		const totalUsers = data?.data?.savingsUserLeaderboards?.items?.length ?? 0;
 		
-		this.logger.debug(`Total savings users from query: ${totalUsers}`);
+		this.logger.debug(`Total savings users: ${totalUsers}`);
 		return { totalUsers };
 	}
 

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -89,8 +89,15 @@ export class SavingsCoreService {
 	async getTotalSavingsUsers(): Promise<{ totalUsers: number }> {
 		this.logger.debug('Getting total savings users count');
 		
-		// Query all unique users who have ever interacted with savings
-		// Using a high limit to ensure we get all users
+		// Option 1: If we have cached leaderboard data, use it (most efficient)
+		if (this.fetchedSavingsUserLeaderboard.length > 0) {
+			const totalUsers = this.fetchedSavingsUserLeaderboard.length;
+			this.logger.debug(`Total savings users from cache: ${totalUsers}`);
+			return { totalUsers };
+		}
+		
+		// Option 2: Query only the IDs with high limit (fallback)
+		// This is still more efficient than loading all fields
 		const data = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`
@@ -106,7 +113,7 @@ export class SavingsCoreService {
 
 		const totalUsers = data?.data?.savingsUserLeaderboards?.items?.length ?? 0;
 		
-		this.logger.debug(`Total savings users: ${totalUsers}`);
+		this.logger.debug(`Total savings users from query: ${totalUsers}`);
 		return { totalUsers };
 	}
 

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -89,22 +89,20 @@ export class SavingsCoreService {
 	async getTotalSavingsUsers(): Promise<{ totalUsers: number }> {
 		this.logger.debug('Getting total savings users count');
 		
-		// Always query fresh data to ensure accuracy
-		// Only fetch IDs to minimize data transfer
+		// Query the pre-aggregated stats from Ponder
 		const data = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`
 				{
-					savingsUserLeaderboards(limit: 100000) {
-						items {
-							id
-						}
+					savingsStats(id: "global") {
+						totalUsers
+						lastUpdated
 					}
 				}
 			`,
 		});
 
-		const totalUsers = data?.data?.savingsUserLeaderboards?.items?.length ?? 0;
+		const totalUsers = data?.data?.savingsStats?.totalUsers ?? 0;
 		
 		this.logger.debug(`Total savings users: ${totalUsers}`);
 		return { totalUsers };

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -90,11 +90,12 @@ export class SavingsCoreService {
 		this.logger.debug('Getting total savings users count');
 		
 		// Query all unique users who have ever interacted with savings
+		// Using a high limit to ensure we get all users
 		const data = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`
 				{
-					savingsUserLeaderboards {
+					savingsUserLeaderboards(limit: 10000) {
 						items {
 							id
 						}


### PR DESCRIPTION
## Summary
Adds a new API endpoint to get the exact count of all unique savings users.

## New Endpoint
- **Path**: `GET /savings/core/info/total-users`
- **Response**: `{ totalUsers: number }`

## Implementation
- Queries all savingsUserLeaderboards from Ponder to get complete user list
- Returns the total count of unique users who have ever interacted with the savings module

## Why This Is Needed
The existing endpoints have limitations:
- Leaderboard endpoint only returns top 50 users
- User tables endpoint is limited for performance
- This new endpoint provides the exact total count needed for UI display

## Testing
Once deployed, test with:
```bash
curl https://api.deuro.com/savings/core/info/total-users
```