### PR TITLE
feat: Add automatic fallback to dev.ponder.deuro.com when main Ponder…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ PORT=3000
 
 CONFIG_APP_URL=https://app.deuro.com
 CONFIG_INDEXER_URL=https://ponder.deuro.com
+CONFIG_INDEXER_FALLBACK_URL=https://dev.ponder.deuro.com
 CONFIG_CHAIN=mainnet
 
 RPC_URL_MAINNET=https://eth-mainnet.g.alchemy.com/v2/[API-KEY]

--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -1,12 +1,31 @@
 import { ApolloClient, ApolloLink, createHttpLink, InMemoryCache } from '@apollo/client/core';
 import { onError } from '@apollo/client/link/error';
+import { Logger } from '@nestjs/common';
 import fetch from 'cross-fetch';
 import { CONFIG } from './api.config';
+
+const logger = new Logger('ApiApolloConfig');
+
+// Fallback URL management
+let fallbackUntil: number | null = null;
+
+function getIndexerUrl(): string {
+	if (fallbackUntil && Date.now() < fallbackUntil) return CONFIG.indexerFallback;
+	if (fallbackUntil) fallbackUntil = null; // Reset expired fallback
+	return CONFIG.indexer;
+}
+
+function activateFallback(): void {
+	if (!fallbackUntil) {
+		fallbackUntil = Date.now() + 10 * 60 * 1000; // 10 minutes
+		logger.log(`[Ponder] Switching to fallback for 10min: ${CONFIG.indexerFallback}`);
+	}
+}
 
 const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
 	if (graphQLErrors) {
 		graphQLErrors.forEach((error) => {
-			console.error(`[GraphQL error in operation: ${operation?.operationName || 'unknown'}]`, {
+			logger.error(`[GraphQL error in operation: ${operation?.operationName || 'unknown'}]`, {
 				message: error.message,
 				locations: error.locations,
 				path: error.path,
@@ -14,16 +33,19 @@ const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
 		});
 	}
 	if (networkError) {
-		console.error(`[Network error in operation: ${operation?.operationName || 'unknown'}]`, {
+		logger.error(`[Network error in operation: ${operation?.operationName || 'unknown'}]`, {
 			message: networkError.message,
 			name: networkError.name,
 			stack: networkError.stack,
 		});
+
+		// Activate fallback on network errors
+		if (getIndexerUrl() === CONFIG.indexer) activateFallback();
 	}
 });
 
 const httpLink = createHttpLink({
-	uri: CONFIG.indexer,
+	uri: getIndexerUrl(),
 	fetch: (uri: RequestInfo | URL, options?: RequestInit) => {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => {
@@ -33,9 +55,15 @@ const httpLink = createHttpLink({
 		return fetch(uri, {
 			...options,
 			signal: controller.signal,
-		}).finally(() => {
-			clearTimeout(timeout);
-		});
+		})
+			.catch((error) => {
+				// Activate fallback on http errors
+				if (getIndexerUrl() === CONFIG.indexer) activateFallback();
+				throw error;
+			})
+			.finally(() => {
+				clearTimeout(timeout);
+			});
 	},
 });
 

--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -45,7 +45,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
 });
 
 const httpLink = createHttpLink({
-	uri: getIndexerUrl(),
+	uri: getIndexerUrl,
 	fetch: (uri: RequestInfo | URL, options?: RequestInit) => {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => {

--- a/api.config.ts
+++ b/api.config.ts
@@ -1,6 +1,7 @@
 import { Chain, createPublicClient, http } from 'viem';
 import { mainnet, polygon } from 'viem/chains';
 
+import { Logger } from '@nestjs/common';
 import * as dotenv from 'dotenv';
 dotenv.config();
 
@@ -13,6 +14,7 @@ if (process.env.COINGECKO_API_KEY === undefined) throw new Error('COINGECKO_API_
 export type ConfigType = {
 	app: string;
 	indexer: string;
+	indexerFallback: string;
 	coingeckoApiKey: string;
 	chain: Chain;
 	network: {
@@ -38,6 +40,7 @@ export type ConfigType = {
 export const CONFIG: ConfigType = {
 	app: process.env.CONFIG_APP_URL || 'https://app.deuro.com',
 	indexer: process.env.CONFIG_INDEXER_URL || 'https://ponder.deuro.com/',
+	indexerFallback: process.env.CONFIG_INDEXER_FALLBACK_URL || 'https://dev.ponder.deuro.com/',
 	coingeckoApiKey: process.env.COINGECKO_API_KEY,
 	chain: process.env.CONFIG_CHAIN === 'polygon' ? polygon : mainnet, // @dev: default mainnet
 	network: {
@@ -60,8 +63,9 @@ export const CONFIG: ConfigType = {
 };
 
 // Start up message
-console.log(`Starting API with this config:`);
-console.log(CONFIG);
+const logger = new Logger('ApiConfig');
+logger.log(`Starting API with this config:`);
+logger.log(CONFIG);
 
 // Refer to https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files
 process.env.NTBA_FIX_350 = 'true';


### PR DESCRIPTION
…… (#55)

* feat: Add automatic fallback to dev.ponder.deuro.com when main Ponder is unavailable

- Implements 10-minute fallback mechanism for improved reliability
- Automatically switches to dev Ponder URL on network errors/timeouts
- Returns to main URL after fallback period expires
- Maintains transparent operation for all GraphQL services

* feat: replace console.log and minor improvements

---------