### PR TITLE
fix: Track all dEURO mints including CoW Protocol swaps (#54)

### DIFF
--- a/ecosystem/ecosystem.stablecoin.types.ts
+++ b/ecosystem/ecosystem.stablecoin.types.ts
@@ -1,5 +1,5 @@
-import { PriceQueryCurrencies } from '../prices/prices.types';
 import { Address } from 'viem';
+import { PriceQueryCurrencies } from '../prices/prices.types';
 
 // --------------------------------------------------------------------------
 // Ponder return types
@@ -10,7 +10,7 @@ export type EcosystemQueryItem = {
 };
 
 export type EcosystemMintQueryItem = {
-	id: string;
+	txHash: string;
 	to: string;
 	value: bigint;
 	blockheight: bigint;

--- a/socialmedia/socialmedia.types.ts
+++ b/socialmedia/socialmedia.types.ts
@@ -3,4 +3,5 @@ export type SocialMediaState = {
 	frontendCodeUpdates: number;
 	tradeUpdates: number;
 	bridgeUpdates: number;
+	mintUpdates: number;
 };

--- a/socialmedia/telegram/telegram.types.ts
+++ b/socialmedia/telegram/telegram.types.ts
@@ -7,7 +7,6 @@ export type TelegramState = {
 	positions: number;
 	challenges: number;
 	bids: number;
-	mintingUpdates: number;
 };
 
 export type TelegramSubscriptionState = {

--- a/socialmedia/twitter/messages/MintingUpdate.message.ts
+++ b/socialmedia/twitter/messages/MintingUpdate.message.ts
@@ -5,13 +5,13 @@ import { formatUnits } from 'viem';
 
 export function MintingUpdateMessage(mint: EcosystemMintQueryItem): string[] {
 	const message = `
-*New dEURO Mint!*
+New dEURO Mint!
 
-🏦 Lending Amount: *${formatCurrency(formatUnits(BigInt(mint.value), 18))}*
-👤 [Lendner](https://etherscan.io/address/${mint.to}) / [TX](https://etherscan.io/tx/${mint.txHash})
-`;
+🏦 Lending Amount: ${formatCurrency(formatUnits(BigInt(mint.value), 18))}
+🔗 Verifiable on the blockchain
+	`;
 
-	const image = `${CONFIG.telegram.imagesDir}/Lending.mp4`;
+	const image = `${CONFIG.twitter.imagesDir}/Lending.png`;
 
 	return [message, image];
 }

--- a/socialmedia/twitter/twitter.service.ts
+++ b/socialmedia/twitter/twitter.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { CONFIG } from 'api.config';
 import { StablecoinBridgeQuery } from 'bridge/bridge.types';
+import { EcosystemMintQueryItem } from 'ecosystem/ecosystem.stablecoin.types';
 import { FrontendCodeRegisteredQuery, FrontendCodeSavingsQuery } from 'frontendcode/frontendcode.types';
 import { readFileSync } from 'fs';
 import { SocialMediaFct, SocialMediaService } from 'socialmedia/socialmedia.service';
@@ -8,6 +9,7 @@ import { TradeQuery } from 'trades/trade.types';
 import { SendTweetV2Params, TwitterApi } from 'twitter-api-v2';
 import { TwitterAccessToken } from './dtos/twitter.dto';
 import { FrontendCodeRegisteredMessage } from './messages/FrontendCodeRegistered.message';
+import { MintingUpdateMessage } from './messages/MintingUpdate.message';
 import { SavingUpdateMessage } from './messages/SavingUpdate.message';
 import { StablecoinBridgeMessage } from './messages/StablecoinBridgeUpdate.message';
 import { TradeMessage } from './messages/Trade.message';
@@ -61,6 +63,12 @@ export class TwitterService implements OnModuleInit, SocialMediaFct {
 		if (BigInt(bridge.amount) === 0n) return;
 		const messageInfo = StablecoinBridgeMessage(bridge, stablecoin);
 		this.sendPost(messageInfo[0], messageInfo[1]);
+	}
+
+	async doSendMintUpdates(mint: EcosystemMintQueryItem): Promise<void> {
+		if (BigInt(mint.value) === 0n) return;
+		const messageInfo = MintingUpdateMessage(mint);
+		await this.sendPost(messageInfo[0], messageInfo[1]);
 	}
 
 	private async sendPost(message: string, media?: string): Promise<string> {


### PR DESCRIPTION
* fix: Track all dEURO mints including CoW Protocol swaps

- Add getRecentMints() method to query all mints from Ponder
- Extend Telegram service to send notifications for all significant mints
- Use correct Ponder GraphQL syntax without where clause filtering
- Add chain-specific transaction explorer URLs

This ensures all dEURO mints trigger social media notifications, not just those with MintingUpdateV2 events.

* chore: Remove unnecessary package-lock.json and restore yarn.lock

* fix: Prevent duplicate notifications and improve error handling

- Add duplicate detection to avoid sending same mint twice
- Track MintingUpdateV2 txHashes to filter them from general mints
- Add try/catch for error handling when fetching mints
- Increase query limit from 100 to 500 to handle more mints
- Use earlier timestamp between generalMints and mintingUpdates to avoid gaps

* fix: Critical bugs in mint notification system

- Fix initial timestamp bug: Use current time instead of future time for mint tracking
- Improve duplicate detection: Check txHash existence before processing
- Simplify timestamp logic: Remove problematic Math.min() that caused missed mints
- Add proper txHash validation before using in URLs
- Clean up filter logic for better readability

* fix: Prevent notification spam on restart and limit batch size

- Initialize mint tracking from 1 hour ago instead of current time
- Prevents duplicate notifications after API restart/deployment
- Add MAX_NOTIFICATIONS limit (10) per update cycle to prevent spam
- Log warning when notification limit is reached
- Balances between catching recent mints and avoiding notification floods

* fix: Simplify notification message - remove unnecessary URL construction

- Remove chain-specific URL logic (dEURO only exists on Polygon)
- Display txHash directly in message instead of constructing URLs
- Simpler and cleaner notification format

* fix: Remove unnecessary complexity from mint tracking

- Reduce query limit from 500 to 50 (sufficient for regular updates)
- Remove unused fields from query (id, blockheight)
- Start tracking from current time instead of 1 hour ago
- Simplifies implementation without affecting functionality

* fix: Radically simplify mint tracking implementation

- Remove all duplicate detection logic (accept occasional duplicates)
- Remove separate generalMints timestamp tracking
- Remove MAX_NOTIFICATIONS limit and logging
- Remove try-catch and error handling
- Remove txHash from types and queries
- Simplify getRecentMints to minimal implementation
- Reuse existing mintingUpdates timestamp for all mints

From 106 lines to ~25 lines of actual new code

* feat: Adapt to the existing implementation

---------