### PR TITLE
Fix stale BTC price in /prices endpoints

### DIFF
--- a/prices/prices.service.ts
+++ b/prices/prices.service.ts
@@ -28,12 +28,29 @@ export class PricesService {
 	private readonly logger = new Logger(this.constructor.name);
 	private fetchedPrices: PriceQueryObjectArray = {};
 	private euroPrice: PriceQueryCurrencies = {};
+	private euroPriceTimestamp: number = 0;
 	private depsPrice: PriceQueryCurrencies = {};
+
+	private static readonly EURO_PRICE_TTL = 60_000; // 60 seconds
 
 	constructor(
 		private readonly positionsService: PositionsService,
 		private readonly deps: EcosystemDepsService
 	) {}
+
+	private isEuroPriceStale(): boolean {
+		return !this.euroPrice?.usd || Date.now() - this.euroPriceTimestamp > PricesService.EURO_PRICE_TTL;
+	}
+
+	private async refreshEuroPriceIfStale(): Promise<void> {
+		if (this.isEuroPriceStale()) {
+			const fetched = await this.fetchEuroPrice();
+			if (fetched) {
+				this.euroPrice = fetched;
+				this.euroPriceTimestamp = Date.now();
+			}
+		}
+	}
 
 	getPrices(): ApiPriceListing {
 		return Object.values(this.fetchedPrices);
@@ -64,8 +81,8 @@ export class PricesService {
 	}
 
 	async getDepsPrice(): Promise<PriceQueryCurrencies> {
-		if (!this.depsPrice) this.depsPrice = await this.fetchFromEcosystemDeps(this.getDeps());
-		if (!this.euroPrice) this.euroPrice = await this.fetchEuroPrice();
+		if (!this.depsPrice?.usd) this.depsPrice = await this.fetchFromEcosystemDeps(this.getDeps());
+		await this.refreshEuroPriceIfStale();
 
 		return {
 			usd: Number(this.depsPrice.usd.toFixed(4)),
@@ -91,7 +108,7 @@ export class PricesService {
 	}
 
 	async getEuroPrice(): Promise<PriceQueryCurrencies> {
-		if (!this.euroPrice) this.euroPrice = await this.fetchEuroPrice();
+		await this.refreshEuroPriceIfStale();
 
 		return {
 			usd: Number(this.euroPrice.usd.toFixed(4)),
@@ -205,7 +222,10 @@ export class PricesService {
 		this.logger.debug('Updating Prices');
 
 		const euroPrice = await this.fetchEuroPrice();
-		if (euroPrice) this.euroPrice = euroPrice;
+		if (euroPrice) {
+			this.euroPrice = euroPrice;
+			this.euroPriceTimestamp = Date.now();
+		}
 
 		const deps = this.getDeps();
 		const m = this.getMint();


### PR DESCRIPTION
## Summary
- The `euroPrice` cache (containing USD/EUR/BTC rates from CoinGecko) had no TTL and only refreshed when new blockchain blocks were detected via `updatePrices()`
- If block detection stalled, the BTC rate could become **hours stale**, causing significant mispricing on BTC-denominated trading pairs (observed ~9% deviation: API implied BTC@68,800 vs actual market BTC@63,194)
- This caused the Hummingbot market making bots to place DEURO-BTC and DEPS-BTC orders at incorrect prices

## Changes
- Add a 60-second TTL (`EURO_PRICE_TTL`) to the `euroPrice` cache
- `getEuroPrice()` and `getDepsPrice()` now self-refresh from CoinGecko if the cache is stale, independent of block detection
- Fix truthy check on empty objects (`{}`) that could prevent initial fetches
- `updatePrices()` still refreshes on every block as before (no change to normal flow)

## Test plan
- [ ] Verify `/prices/eur` returns current BTC rate after deploy
- [ ] Compare `data["btc"]` implied BTC/USD rate against actual BTC/USDT market price
- [ ] Confirm BTC rate refreshes within 60s even if no new blocks are detected