### PR TITLE
Fix EUR/USD price source: replace USD+ with Tether

### DIFF
--- a/prices/prices.service.ts
+++ b/prices/prices.service.ts
@@ -164,8 +164,8 @@ export class PricesService {
 	}
 
 	async fetchEuroPrice(): Promise<PriceQueryCurrencies | null> {
-		const url = `/api/v3/simple/price?ids=usd&vs_currencies=eur%2Cbtc`;
-		const data = await(await COINGECKO_CLIENT(url)).json();
+		const url = `/api/v3/simple/price?ids=tether&vs_currencies=eur%2Cbtc`;
+		const data = await (await COINGECKO_CLIENT(url)).json();
 		if (data.status) {
 			this.logger.debug(data.status?.error_message || 'Error fetching price from coingecko');
 			return null;
@@ -173,8 +173,8 @@ export class PricesService {
 
 		return {
 			eur: 1,
-			usd: 1 / Number(data.usd.eur),
-			btc: 1 / Number(data.usd.eur / data.usd.btc),
+			usd: 1 / Number(data.tether.eur),
+			btc: 1 / Number(data.tether.eur / data.tether.btc),
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Replace CoinGecko `ids=usd` (Overnight.fi USD+, $48M mcap) with `ids=tether` (USDT, $140B mcap) in `fetchEuroPrice()`
- USD+ was causing 1.5-2.7% price inflation in EUR/USD reference, leading to ~363 USDT losses on market-making trades
- Tether maintains consistent <0.1% peg to $1.00 and provides accurate EUR/USD conversion

## Test plan
- [ ] Verify CoinGecko API response: `curl "https://api.coingecko.com/api/v3/simple/price?ids=tether&vs_currencies=eur,btc,usd"`
- [ ] Compare EUR/USD result with actual market rate (should be within 0.1%)
- [ ] After deployment: verify `GET /prices/eur` returns correct EUR/USD rate
- [ ] Monitor market-making trades for correct pricing