### PR TITLE
Address handling: normalize external input, trust Ponder fields

### DIFF
--- a/ecosystem/ecosystem.minter.service.ts
+++ b/ecosystem/ecosystem.minter.service.ts
@@ -60,7 +60,7 @@ export class EcosystemMinterService {
 
 		const list: MinterQueryObjectArray = {};
 		for (const m of data.minters.items as MinterQuery[]) {
-			list[m.id.toLowerCase() as Address] = {
+			list[m.id as Address] = {
 				id: m.id,
 				txHash: m.txHash,
 				minter: m.minter,

--- a/ecosystem/ecosystem.stablecoin.service.ts
+++ b/ecosystem/ecosystem.stablecoin.service.ts
@@ -150,7 +150,7 @@ export class EcosystemStablecoinService {
 		const e = response.data.mintBurnAddressMappers.items as MintBurnAddressMapperQueryItem[];
 
 		for (const item of e) {
-			this.ecosystemMintBurnMapping[item.id] = {
+			this.ecosystemMintBurnMapping[item.id as Address] = {
 				mint: item.mint,
 				burn: item.burn,
 			};

--- a/positions/positions.service.ts
+++ b/positions/positions.service.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client/core';
 import { ADDRESS, PositionV2ABI, SavingsABI } from '@deuro/eurocoin';
 import { Injectable, Logger } from '@nestjs/common';
 import { FIVEDAYS_MS } from 'utils/const-helper';
-import { Address, erc20Abi, getAddress } from 'viem';
+import { Address, erc20Abi } from 'viem';
 import { CONFIG, VIEM_CONFIG } from '../api.config';
 import { PONDER_CLIENT } from '../api.apollo.config';
 import {
@@ -64,7 +64,7 @@ export class PositionsService {
 	getPositionsOwners(): ApiPositionsOwners {
 		const ow: OwnersPositionsObjectArray = {};
 		for (const p of Object.values(this.fetchedPositions)) {
-			const owner = p.owner.toLowerCase();
+			const owner = p.owner as Address;
 			if (!ow[owner]) ow[owner] = [];
 			ow[owner].push(p);
 		}
@@ -199,10 +199,10 @@ export class PositionsService {
 			const entry: PositionQuery = {
 				version: 2,
 
-				position: getAddress(p.position),
-				owner: getAddress(p.owner),
-				deuro: getAddress(p.deuro),
-				collateral: getAddress(p.collateral),
+				position: p.position as Address,
+				owner: p.owner as Address,
+				deuro: p.deuro as Address,
+				collateral: p.collateral as Address,
 				price: p.price,
 
 				created: p.created,
@@ -210,7 +210,7 @@ export class PositionsService {
 				isClone: p.isClone,
 				denied: p.denied,
 				closed: p.closed,
-				original: getAddress(p.original),
+				original: p.original as Address,
 
 				minimumCollateral: p.minimumCollateral,
 				annualInterestPPM: leadrate + p.riskPremiumPPM,
@@ -239,7 +239,7 @@ export class PositionsService {
 				interest: typeof i === 'bigint' ? i.toString() : '0',
 			};
 
-			list[p.position.toLowerCase() as Address] = entry;
+			list[p.position as Address] = entry;
 		}
 
 		const a = Object.keys(list).length;
@@ -313,7 +313,7 @@ export class PositionsService {
 
 		for (let idx = 0; idx < items.length; idx++) {
 			const m = items[idx] as MintingUpdateQuery;
-			const k = m.position.toLowerCase() as Address;
+			const k = m.position as Address;
 
 			if (list[k] === undefined) list[k] = [];
 
@@ -323,10 +323,10 @@ export class PositionsService {
 				id: m.id,
 				txHash: m.txHash,
 				created: parseInt(m.created as any),
-				position: getAddress(m.position),
-				owner: getAddress(m.owner),
+				position: m.position as Address,
+				owner: m.owner as Address,
 				isClone: m.isClone,
-				collateral: getAddress(m.collateral),
+				collateral: m.collateral as Address,
 				collateralName: m.collateralName,
 				collateralSymbol: m.collateralSymbol,
 				collateralDecimals: m.collateralDecimals,

--- a/savings/savings.core.controller.ts
+++ b/savings/savings.core.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Param } from '@nestjs/common';
 import { ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SavingsCoreService } from './savings.core.service';
 import { ApiSavingsInfo, ApiSavingsUserTable, ApiSavingsUserLeaderboard } from './savings.core.types';
-import { Address, zeroAddress } from 'viem';
+import { isAddress, zeroAddress } from 'viem';
+import { normalizedAddress } from 'utils/address-normalize';
 
 @ApiTags('Savings Controller')
 @Controller('savings/core')
@@ -31,7 +32,12 @@ export class SavingsCoreController {
 	})
 	async getUserTable(@Param('address') address: string): Promise<ApiSavingsUserTable> {
 		const keywords: string[] = ['0', 'all', 'zero', 'zeroAddress', zeroAddress];
-		if (keywords.includes(address)) address = zeroAddress;
-		return await this.savings.getUserTables(address as Address);
+		if (keywords.includes(address)) {
+			return await this.savings.getUserTables(zeroAddress);
+		}
+		if (!isAddress(address)) {
+			throw new BadRequestException('Invalid address');
+		}
+		return await this.savings.getUserTables(normalizedAddress(address));
 	}
 }

--- a/savings/savings.core.service.ts
+++ b/savings/savings.core.service.ts
@@ -5,6 +5,7 @@ import { PONDER_CLIENT } from 'api.apollo.config';
 import { VIEM_CONFIG } from 'api.config';
 import { EcosystemStablecoinService } from 'ecosystem/ecosystem.stablecoin.service';
 import { Address, formatUnits, zeroAddress } from 'viem';
+import { addressForPonderFilter } from 'utils/address-normalize';
 import { ApiSavingsInfo, ApiSavingsUserLeaderboard, ApiSavingsUserTable } from './savings.core.types';
 import { SavingsLeadrateService } from './savings.leadrate.service';
 
@@ -63,15 +64,16 @@ export class SavingsCoreService {
 
 		const mapped = await Promise.all(
 			items.map(async (item) => {
+				const account = item.id as Address;
 				const unrealizedInterest = await VIEM_CONFIG.readContract({
 					address: ADDRESS[VIEM_CONFIG.chain.id].savingsGateway,
 					abi: SavingsGatewayABI,
 					functionName: 'accruedInterest',
-					args: [item.id],
+					args: [account],
 				});
 
 				return {
-					account: item.id,
+					account,
 					amountSaved: item.amountSaved,
 					unrealizedInterest: unrealizedInterest.toString(),
 					interestReceived: item.interestReceived,
@@ -87,7 +89,7 @@ export class SavingsCoreService {
 	}
 
 	async getUserTables(userAddress: Address, limit: number = 15): Promise<ApiSavingsUserTable> {
-		const user: Address = userAddress == zeroAddress ? zeroAddress : (userAddress.toLowerCase() as Address);
+		const user = addressForPonderFilter(userAddress);
 		const savedFetched = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`

--- a/trades/trade.service.ts
+++ b/trades/trade.service.ts
@@ -1,6 +1,8 @@
 import { gql } from '@apollo/client/core';
 import { Injectable } from '@nestjs/common';
 import { PONDER_CLIENT } from 'api.apollo.config';
+import { addressForPonderFilter } from 'utils/address-normalize';
+import { Address } from 'viem';
 import { TradeQuery } from './trade.types';
 
 @Injectable()
@@ -35,13 +37,14 @@ export class TradesService {
 	}
 
 	async getTotalShares(trader: string): Promise<bigint> {
+		const traderNorm = addressForPonderFilter(trader as Address);
 		const tradeFetched = await PONDER_CLIENT.query({
 			fetchPolicy: 'no-cache',
 			query: gql`
                 query GetTraderShares {
                     trades(
                         where: { 
-                            trader: "${trader}"
+                            trader: "${traderNorm}"
                         }
                     ) {
                         items {

--- a/utils/address-normalize.ts
+++ b/utils/address-normalize.ts
@@ -1,0 +1,12 @@
+import { Address, getAddress, zeroAddress } from 'viem';
+
+/** Lowercase 0x address for Ponder GraphQL filters (indexed storage is lowercase). */
+export function addressForPonderFilter(addr: Address): Address {
+	if (addr === zeroAddress) return zeroAddress;
+	return getAddress(addr).toLowerCase() as Address;
+}
+
+/** Validates with getAddress, returns lowercase hex for keys and API fields. */
+export function normalizedAddress(addr: string): Address {
+	return getAddress(addr as `0x${string}`).toLowerCase() as Address;
+}


### PR DESCRIPTION
## Summary
- Introduces `utils/address-normalize.ts` with `addressForPonderFilter` (lowercase for GraphQL filters) and `normalizedAddress` (validate + lowercase for path/query input).
- **External input:** savings `user/:address` validates with `isAddress` and normalizes; `getUserTables` still uses `addressForPonderFilter` so filters match Ponder storage; `getTotalShares` lowercases `trader` in the GraphQL filter.
- **Ponder-sourced data:** positions, savings leaderboard, mint/burn mapping, and minters use indexer strings as-is (no extra `getAddress` pass-through).

## Notes
Mint/burn map keys follow Ponder `id` casing (expected lowercase from indexer).