### PR TITLE
Replace Azure deploy with SSH deploy via Cloudflare Tunnel

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -45,9 +45,6 @@ jobs:
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to dfxdev
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key

--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -7,8 +7,6 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-api:beta
-  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
-  DEPLOY_USER: dfxdev
   DEPLOY_SERVICE: deuro-api
 
 jobs:
@@ -41,16 +39,16 @@ jobs:
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
-      - name: Deploy to dfxdev
+      - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
-            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-api:beta
+  DOCKER_TAGS: deurocom/api:beta
   DEPLOY_SERVICE: deuro-api
 
 jobs:

--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -7,17 +7,14 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-api:beta
-  AZURE_RESOURCE_GROUP: rg-dfx-api-dev
-  AZURE_CONTAINER_APP: ca-dfx-dea-dev
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
+  DEPLOY_USER: dfxdev
+  DEPLOY_SERVICE: deuro-api
 
 jobs:
   build-and-deploy:
-    name: Build, test and deploy to DEV
+    name: Build and deploy to DEV
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +25,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -37,19 +37,23 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64,linux/arm64
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
-
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-      - name: Logout from Azure
+      - name: Install cloudflared
         run: |
-          az logout
-        if: always()
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to dfxdev
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"


### PR DESCRIPTION
## Summary
Replace Azure Container App deployment with SSH deployment via Cloudflare Tunnel.

- Docker Hub push (`:beta` tag) remains unchanged  
- Deploy uses command-restricted SSH key
- Host and user details stored as secrets

## Required GitHub Secrets
| Secret | Description |
|---|---|
| `DEPLOY_SSH_KEY` | SSH private key (ed25519) |
| `DEPLOY_SSH_KNOWN_HOSTS` | SSH host key verification |
| `DEPLOY_HOST` | Target SSH hostname |
| `DEPLOY_USER` | Target SSH username |