### PR TITLE
Switch to ARM64-only Docker builds for Apple Silicon servers

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to DEV
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,9 +23,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -35,11 +32,11 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to server

--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -7,17 +7,12 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-api:latest
-  AZURE_RESOURCE_GROUP: rg-dfx-api-prd
-  AZURE_CONTAINER_APP: ca-dfx-dea-prd
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_SERVICE: deuro-api
 
 jobs:
   build-and-deploy:
     name: Build, test and deploy to PRD
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,19 +32,20 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
-
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-      - name: Logout from Azure
+      - name: Install cloudflared
         run: |
-          az logout
-        if: always()
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"


### PR DESCRIPTION
## Summary
- Switch CI runners from `ubuntu-latest` (x86) to `ubuntu-24.04-arm` (native ARM64)
- Remove QEMU emulation step from DEV workflow (no longer needed for cross-compilation)
- Build only `linux/arm64` Docker images instead of multi-arch (`linux/amd64,linux/arm64`)
- Use `cloudflared-linux-arm64` binary matching the ARM64 runner
- Replace Azure Container App deployment with SSH deploy via cloudflared for PRD workflow

## Test plan
- [ ] Verify DEV workflow builds and deploys successfully on push to develop
- [ ] Verify PRD workflow builds and deploys successfully on push to main
- [ ] Confirm Docker images are ARM64-only on Docker Hub
- [ ] Verify PRD SSH secrets are configured: `DEPLOY_PRD_SSH_KEY`, `DEPLOY_PRD_SSH_KNOWN_HOSTS`, `DEPLOY_PRD_HOST`, `DEPLOY_PRD_USER`