### PR TITLE
Fix DEPS GraphQL query for updated Ponder schema

### DIFF
--- a/ecosystem/ecosystem.deps.service.ts
+++ b/ecosystem/ecosystem.deps.service.ts
@@ -54,7 +54,7 @@ export class EcosystemDepsService {
 			fetchPolicy: 'no-cache',
 			query: gql`
 				query GetDEPS {
-					depss(orderBy: "id", limit: 1000) {
+					dEPSs(orderBy: "id", limit: 1000) {
 						items {
 							id
 							profits
@@ -65,12 +65,12 @@ export class EcosystemDepsService {
 			`,
 		});
 
-		if (!profitLossPonder.data || !profitLossPonder.data.depss.items.length) {
+		if (!profitLossPonder.data || !profitLossPonder.data.dEPSs.items.length) {
 			this.logger.warn('No profitLossPonder data found.');
 			return;
 		}
 
-		const d = profitLossPonder.data.depss.items.at(0);
+		const d = profitLossPonder.data.dEPSs.items.at(0);
 		const unrealizedProfit = this.getUnrealizedProfit();
 		const earningsData: ApiEcosystemDepsInfo['earnings'] = {
 			profit: parseFloat(formatUnits(d.profits, 18)),


### PR DESCRIPTION
## Summary
- Ponder indexer schema changed entity name from `depss` to `dEPSs`
- The `GetDEPS` query failed on every block (~12s) with a GraphQL validation error
- Updated query and all data access paths to use the new entity name

## Test plan
- [x] Verified `dEPSs` query works against production Ponder endpoint
- [x] Build passes locally
- [ ] Verify errors disappear in Loki after deployment