### PR TITLE
Revert dEPSs to depss to match Ponder schema

### DIFF
--- a/ecosystem/ecosystem.deps.service.ts
+++ b/ecosystem/ecosystem.deps.service.ts
@@ -54,7 +54,7 @@ export class EcosystemDepsService {
 			fetchPolicy: 'no-cache',
 			query: gql`
 				query GetDEPS {
-					dEPSs(orderBy: "id", limit: 1000) {
+					depss(orderBy: "id", limit: 1000) {
 						items {
 							id
 							profits
@@ -65,12 +65,12 @@ export class EcosystemDepsService {
 			`,
 		});
 
-		if (!profitLossPonder.data || !profitLossPonder.data.dEPSs.items.length) {
+		if (!profitLossPonder.data || !profitLossPonder.data.depss.items.length) {
 			this.logger.warn('No profitLossPonder data found.');
 			return;
 		}
 
-		const d = profitLossPonder.data.dEPSs.items.at(0);
+		const d = profitLossPonder.data.depss.items.at(0);
 		const unrealizedProfit = this.getUnrealizedProfit();
 		const earningsData: ApiEcosystemDepsInfo['earnings'] = {
 			profit: parseFloat(formatUnits(d.profits, 18)),


### PR DESCRIPTION
## Summary
- PR #86 incorrectly renamed `depss` → `dEPSs` in the GetDEPS GraphQL query
- The Ponder schema defines the table as lowercase `deps`, so the plural field is `depss`
- This mismatch causes `GRAPHQL_VALIDATION_FAILED` on every update cycle (~30k errors/hour on DEV)

## Test plan
- [ ] Verify GetDEPS query succeeds after deploy
- [ ] Confirm error logs stop in Grafana Log Viewer