### PR TITLE
Log error message and stack trace in SocialMediaService catch handlers

### DIFF
--- a/socialmedia/socialmedia.service.ts
+++ b/socialmedia/socialmedia.service.ts
@@ -74,7 +74,7 @@ export class SocialMediaService {
 				await value.doSendUpdates();
 			}
 		} catch (e) {
-			this.logger.error('Error while sending updates:', e);
+			this.logger.error(`Error while sending updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 
@@ -94,7 +94,7 @@ export class SocialMediaService {
 				}
 			}
 		} catch (e) {
-			this.logger.error('Error while sending saving updates:', e);
+			this.logger.error(`Error while sending saving updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 
@@ -113,7 +113,7 @@ export class SocialMediaService {
 				}
 			}
 		} catch (e) {
-			this.logger.error('Error while sending frontend code updates:', e);
+			this.logger.error(`Error while sending frontend code updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 
@@ -137,7 +137,7 @@ export class SocialMediaService {
 				}
 			}
 		} catch (e) {
-			this.logger.error('Error while sending trade updates:', e);
+			this.logger.error(`Error while sending trade updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 
@@ -160,7 +160,7 @@ export class SocialMediaService {
 				}
 			}
 		} catch (e) {
-			this.logger.error('Error while sending bridge updates:', e);
+			this.logger.error(`Error while sending bridge updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 
@@ -181,7 +181,7 @@ export class SocialMediaService {
 				}
 			}
 		} catch (e) {
-			this.logger.error('Error while sending mint updates:', e);
+			this.logger.error(`Error while sending mint updates: ${e?.message ?? e}`, e?.stack);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Passing an `Error` object as the second argument to NestJS's `Logger.error()` makes it interpret the error as `trace: string`. The logger then calls `toString()`, which only yields `"Error: <msg>"` and drops the actual stack.
- Log lines like `error [SocialMediaService]: Error while sending saving updates:` appear without any detail — the real cause is silently lost.
- Changes all six catch handlers to log `${e.message}` in the message and pass `e.stack` as the trace argument.

## Test plan
- [ ] Confirm next SocialMediaService exception in deploy logs includes the error message + stack