### PR TITLE
fix(socialmedia): handle empty frontend code in ref link label

### DIFF
--- a/socialmedia/socialmedia.helper.ts
+++ b/socialmedia/socialmedia.helper.ts
@@ -13,17 +13,19 @@ export function delay(ms: number): Promise<void> {
 }
 
 export function createRefCodeLabelLink(frontendCode: string): string {
+	if (!frontendCode) return '';
+
 	if (frontendCode.toLowerCase() === DEURO_WALLET_FRONTEND_CODE.toLowerCase()) {
 		return `dEURO Wallet`;
 	}
 
 	const refCode = createRefCode(frontendCode);
 	if (!refCode) return '';
-	
+
 	// Special case for Cake Wallet
 	if (refCode === 'Cake Wallet') {
 		return `[${refCode}](https://cakewallet.com/)`;
 	}
-	
+
 	return `[${refCode}](https://app.deuro.com?ref=${refCode})`;
 }


### PR DESCRIPTION
## Summary

Adds an early return in `createRefCodeLabelLink` when `frontendCode` is falsy, so downstream string handling is not invoked on missing values.

## Changes

- `socialmedia/socialmedia.helper.ts`: guard before `toLowerCase()` and ref code logic; minor whitespace cleanup.