### PR TITLE
Telegram alerts for expiring and expired positions

### DIFF
--- a/socialmedia/telegram/dtos/groups.dto.ts
+++ b/socialmedia/telegram/dtos/groups.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class Groups {
 	// @dev: react/nextjs/ts causes type error. (lint in yarn install, deployment)
@@ -8,6 +8,10 @@ export class Groups {
 		this.createdAt = 0;
 		this.updatedAt = 0;
 		this.groups = [];
+		this.alertedMiniLifetime = [];
+		this.alertedExpiringSoon = [];
+		this.alertedExpired = [];
+		this.alertedPhase2 = [];
 	}
 
 	@IsString()
@@ -22,4 +26,28 @@ export class Groups {
 	@IsArray()
 	@IsString({ each: true })
 	groups: string[];
+
+	// Per-address alert dedup. Persisting these means a service restart does not silently
+	// drop alerts for positions that were actionable when the service went down, and a
+	// telegram outage does not lose alerts (positions stay un-listed until delivery
+	// confirms). @IsOptional so older backup files without these fields still validate.
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	alertedMiniLifetime: string[];
+
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	alertedExpiringSoon: string[];
+
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	alertedExpired: string[];
+
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	alertedPhase2: string[];
 }

--- a/socialmedia/telegram/messages/PositionExpired.message.ts
+++ b/socialmedia/telegram/messages/PositionExpired.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, safeMarkdown } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -8,6 +8,8 @@ export function PositionExpiredMessage(position: PositionQuery): string {
 	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
 	const duration: number = position.challengePeriod * 1000;
+	const collateralName = safeMarkdown(position.collateralName);
+	const collateralSymbol = safeMarkdown(position.collateralSymbol);
 
 	const begin = new Date(position.expiration * 1000);
 	const mid = new Date(position.expiration * 1000 + 1 * duration);
@@ -23,23 +25,23 @@ Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} 
 Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
 Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
+Collateral: ${collateralName} (${collateralSymbol})
 At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+Balance: ${formatCurrency(bal, 2, 2)} ${collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${collateralSymbol}
 `;
 
 	const body = `
 *ForceSell is available*
 
 Declines (10x -> 1x Price): ${begin.toUTCString()}
-Price (10x): ${formatCurrency(price * 10, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+Price (10x): ${formatCurrency(price * 10, 2, 2)} dEURO per 1 ${collateralSymbol}
 
 Continues (1x -> 0x Price): ${mid.toUTCString()}
-Price (1x): ${formatCurrency(price, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+Price (1x): ${formatCurrency(price, 2, 2)} dEURO per 1 ${collateralSymbol}
 
 Zero: ${zero.toUTCString()}
-Price (0x): 0.00 dEURO per 1 ${position.collateralSymbol}
+Price (0x): 0.00 dEURO per 1 ${collateralSymbol}
 `;
 
 	const footer = `

--- a/socialmedia/telegram/messages/PositionExpired.message.ts
+++ b/socialmedia/telegram/messages/PositionExpired.message.ts
@@ -1,0 +1,56 @@
+import { PositionQuery } from 'positions/positions.types';
+import { formatCurrency } from 'utils/format';
+import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
+import { formatUnits } from 'viem';
+
+export function PositionExpiredMessage(position: PositionQuery): string {
+	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
+	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const duration: number = position.challengePeriod * 1000;
+
+	const begin = new Date(position.expiration * 1000);
+	const mid = new Date(position.expiration * 1000 + 1 * duration);
+	const zero = new Date(position.expiration * 1000 + 2 * duration);
+
+	const header = `
+*Position is expired*
+
+Position: ${position.position} (v${position.version})
+Owner: ${position.owner}
+
+Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
+Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
+
+Collateral: ${position.collateralName} (${position.collateralSymbol})
+At: ${position.collateral}
+Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+`;
+
+	const body = `
+*ForceSell is available*
+
+Declines (10x -> 1x Price): ${begin.toUTCString()}
+Price (10x): ${formatCurrency(price * 10, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+
+Continues (1x -> 0x Price): ${mid.toUTCString()}
+Price (1x): ${formatCurrency(price, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+
+Zero: ${zero.toUTCString()}
+Price (0x): 0.00 dEURO per 1 ${position.collateralSymbol}
+`;
+
+	const footer = `
+
+[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
+[Buy Collateral](${AppUrl(`/monitoring/${position.position}/forceSell`)})
+
+[Explorer Position](${ExplorerAddressUrl(position.position)})
+[Explorer Owner](${ExplorerAddressUrl(position.owner)})
+[Explorer Collateral](${ExplorerAddressUrl(position.collateral)})
+`;
+
+	return header + body + footer;
+}

--- a/socialmedia/telegram/messages/PositionExpiringSoon.message.ts
+++ b/socialmedia/telegram/messages/PositionExpiringSoon.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, safeMarkdown } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -8,6 +8,8 @@ export function PositionExpiringSoonMessage(position: PositionQuery): string {
 	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
 	const date = new Date(position.expiration * 1000);
+	const collateralName = safeMarkdown(position.collateralName);
+	const collateralSymbol = safeMarkdown(position.collateralSymbol);
 
 	return `
 *Position will expire soon*
@@ -21,10 +23,10 @@ Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
 Expiration: ${formatCurrency((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24)} days
 At: ${date.toUTCString()}
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
+Collateral: ${collateralName} (${collateralSymbol})
 At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+Balance: ${formatCurrency(bal, 2, 2)} ${collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${collateralSymbol}
 Price: ${formatCurrency(price, 2, 2)} dEURO
 
 [Overview Position](${AppUrl(`/monitoring/${position.position}`)})

--- a/socialmedia/telegram/messages/PositionExpiringSoon.message.ts
+++ b/socialmedia/telegram/messages/PositionExpiringSoon.message.ts
@@ -1,0 +1,36 @@
+import { PositionQuery } from 'positions/positions.types';
+import { formatCurrency } from 'utils/format';
+import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
+import { formatUnits } from 'viem';
+
+export function PositionExpiringSoonMessage(position: PositionQuery): string {
+	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
+	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const date = new Date(position.expiration * 1000);
+
+	return `
+*Position will expire soon*
+
+Position: ${position.position} (v${position.version})
+Owner: ${position.owner}
+
+Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
+Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
+Expiration: ${formatCurrency((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24)} days
+At: ${date.toUTCString()}
+
+Collateral: ${position.collateralName} (${position.collateralSymbol})
+At: ${position.collateral}
+Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+Price: ${formatCurrency(price, 2, 2)} dEURO
+
+[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
+
+[Explorer Position](${ExplorerAddressUrl(position.position)})
+[Explorer Owner](${ExplorerAddressUrl(position.owner)})
+[Explorer Collateral](${ExplorerAddressUrl(position.collateral)})
+                        `;
+}

--- a/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
+++ b/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
@@ -6,6 +6,7 @@ import { formatUnits } from 'viem';
 export function PositionMiniLifetimeMessage(position: PositionQuery): string {
 	const lifetimeSeconds = position.expiration - position.created;
 	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
 
 	return `
@@ -16,10 +17,13 @@ Owner: ${position.owner}
 
 Lifetime: ${lifetimeSeconds} seconds
 Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
 Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
 
 Collateral: ${position.collateralName} (${position.collateralSymbol})
+At: ${position.collateral}
 Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
 Price: ${formatCurrency(price, 2, 2)} dEURO
 
 This pattern matches the WFPS forced-sale attack vector — a clone with

--- a/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
+++ b/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, safeMarkdown } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -8,6 +8,8 @@ export function PositionMiniLifetimeMessage(position: PositionQuery): string {
 	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const collateralName = safeMarkdown(position.collateralName);
+	const collateralSymbol = safeMarkdown(position.collateralSymbol);
 
 	return `
 *Suspicious clone detected*
@@ -20,10 +22,10 @@ Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} 
 Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
 Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
+Collateral: ${collateralName} (${collateralSymbol})
 At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+Balance: ${formatCurrency(bal, 2, 2)} ${collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${collateralSymbol}
 Price: ${formatCurrency(price, 2, 2)} dEURO
 
 This pattern matches the WFPS forced-sale attack vector — a clone with

--- a/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
+++ b/socialmedia/telegram/messages/PositionMiniLifetime.message.ts
@@ -1,0 +1,36 @@
+import { PositionQuery } from 'positions/positions.types';
+import { formatCurrency } from 'utils/format';
+import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
+import { formatUnits } from 'viem';
+
+export function PositionMiniLifetimeMessage(position: PositionQuery): string {
+	const lifetimeSeconds = position.expiration - position.created;
+	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+
+	return `
+*Suspicious clone detected*
+
+Position: ${position.position} (v${position.version})
+Owner: ${position.owner}
+
+Lifetime: ${lifetimeSeconds} seconds
+Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
+
+Collateral: ${position.collateralName} (${position.collateralSymbol})
+Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+Price: ${formatCurrency(price, 2, 2)} dEURO
+
+This pattern matches the WFPS forced-sale attack vector — a clone with
+sub-day lifetime, set up to be drained via expiredPurchasePrice decay.
+Mitigation: open a challenge or call buyExpiredCollateral once the
+position enters phase 2.
+
+[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
+
+[Explorer Position](${ExplorerAddressUrl(position.position)})
+[Explorer Owner](${ExplorerAddressUrl(position.owner)})
+[Explorer Collateral](${ExplorerAddressUrl(position.collateral)})
+                        `;
+}

--- a/socialmedia/telegram/messages/PositionPhase2.message.ts
+++ b/socialmedia/telegram/messages/PositionPhase2.message.ts
@@ -1,0 +1,45 @@
+import { PositionQuery } from 'positions/positions.types';
+import { formatCurrency } from 'utils/format';
+import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
+import { formatUnits } from 'viem';
+
+/**
+ * Fired once when an expired position enters phase 2 of the forced-sale decay
+ * (price drops linearly from 1× to 0× liq-price over one challengePeriod).
+ * Phase 2 is the actionable arbitrage window before the equity reserve absorbs
+ * the loss via coverLoss.
+ */
+export function PositionPhase2Message(position: PositionQuery): string {
+	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const phase2Start = new Date((position.expiration + position.challengePeriod) * 1000);
+	const phase2End = new Date((position.expiration + position.challengePeriod * 2) * 1000);
+
+	return `
+*Forced-sale phase 2 entered*
+
+Position: ${position.position} (v${position.version})
+Owner: ${position.owner}
+
+Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Liq. Price: ${formatCurrency(price, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+
+Phase 2 window:
+Start: ${phase2Start.toUTCString()}  (price = 1× liq)
+End:   ${phase2End.toUTCString()}  (price = 0)
+
+Collateral: ${position.collateralName} (${position.collateralSymbol})
+Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+
+This is the arbitrage window — call MintingHub.buyExpiredCollateral
+to repay the debt at decay price before the equity reserve covers
+the gap.
+
+[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
+[Buy Collateral](${AppUrl(`/monitoring/${position.position}/forceSell`)})
+
+[Explorer Position](${ExplorerAddressUrl(position.position)})
+[Explorer Owner](${ExplorerAddressUrl(position.owner)})
+[Explorer Collateral](${ExplorerAddressUrl(position.collateral)})
+                        `;
+}

--- a/socialmedia/telegram/messages/PositionPhase2.message.ts
+++ b/socialmedia/telegram/messages/PositionPhase2.message.ts
@@ -11,6 +11,7 @@ import { formatUnits } from 'viem';
  */
 export function PositionPhase2Message(position: PositionQuery): string {
 	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
 	const phase2Start = new Date((position.expiration + position.challengePeriod) * 1000);
 	const phase2End = new Date((position.expiration + position.challengePeriod * 2) * 1000);
@@ -22,6 +23,8 @@ Position: ${position.position} (v${position.version})
 Owner: ${position.owner}
 
 Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
+Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
+Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
 Liq. Price: ${formatCurrency(price, 2, 2)} dEURO per 1 ${position.collateralSymbol}
 
 Phase 2 window:
@@ -29,7 +32,9 @@ Start: ${phase2Start.toUTCString()}  (price = 1× liq)
 End:   ${phase2End.toUTCString()}  (price = 0)
 
 Collateral: ${position.collateralName} (${position.collateralSymbol})
+At: ${position.collateral}
 Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
 
 This is the arbitrage window — call MintingHub.buyExpiredCollateral
 to repay the debt at decay price before the equity reserve covers

--- a/socialmedia/telegram/messages/PositionPhase2.message.ts
+++ b/socialmedia/telegram/messages/PositionPhase2.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, safeMarkdown } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -13,6 +13,8 @@ export function PositionPhase2Message(position: PositionQuery): string {
 	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
 	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const collateralName = safeMarkdown(position.collateralName);
+	const collateralSymbol = safeMarkdown(position.collateralSymbol);
 	const phase2Start = new Date((position.expiration + position.challengePeriod) * 1000);
 	const phase2End = new Date((position.expiration + position.challengePeriod * 2) * 1000);
 
@@ -25,16 +27,16 @@ Owner: ${position.owner}
 Principal: ${formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} dEURO
 Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
 Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
-Liq. Price: ${formatCurrency(price, 2, 2)} dEURO per 1 ${position.collateralSymbol}
+Liq. Price: ${formatCurrency(price, 2, 2)} dEURO per 1 ${collateralSymbol}
 
 Phase 2 window:
 Start: ${phase2Start.toUTCString()}  (price = 1× liq)
 End:   ${phase2End.toUTCString()}  (price = 0)
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
+Collateral: ${collateralName} (${collateralSymbol})
 At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
+Balance: ${formatCurrency(bal, 2, 2)} ${collateralSymbol}
+Bal. min.: ${formatCurrency(min, 2, 2)} ${collateralSymbol}
 
 This is the arbitrage window — call MintingHub.buyExpiredCollateral
 to repay the debt at decay price before the equity reserve covers

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -210,12 +210,15 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		}
 
 		// Positions expired (only those with outstanding principal — clean exits are not actionable)
+		// Skip if already in phase 2: the phase-2 watcher fires in the same cycle with more
+		// actionable info (decay status), no need to double-alert.
 		const expiredPositions = openPositions.filter((p) => {
 			if (BigInt(p.principal || '0') === 0n) return false;
 			const stateDate = new Date(this.telegramState.positionsExpired).getTime();
 			const isExpired = p.expiration * 1000 < Date.now();
+			const alreadyInPhase2 = (p.expiration + p.challengePeriod) * 1000 <= Date.now();
 			const isNew = isExpired && stateDate < p.expiration * 1000;
-			return isExpired && isNew;
+			return isExpired && isNew && !alreadyInPhase2;
 		});
 		if (expiredPositions.length > 0) {
 			this.telegramState.positionsExpired = Date.now();

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -31,6 +31,9 @@ import { StablecoinBridgeMessage } from './messages/StablecoinBridgeUpdate.messa
 import { TradeMessage } from './messages/Trade.message';
 import { TelegramGroupState, TelegramState } from './telegram.types';
 
+// Stay under telegram per-chat rate limit (~30 msg/s) when bursting position-lifecycle alerts.
+const TELEGRAM_THROTTLE_MS = 100;
+
 @Injectable()
 export class TelegramService implements OnModuleInit, SocialMediaFct {
 	private readonly logger = new Logger(this.constructor.name);
@@ -192,7 +195,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		if (miniLifetimePositions.length > 0) {
 			this.telegramState.positionsMiniLifetime = Date.now();
 			for (const p of miniLifetimePositions) {
-				this.sendMessageAll(PositionMiniLifetimeMessage(p));
+				await this.sendMessageAll(PositionMiniLifetimeMessage(p));
+				await this.sleep(TELEGRAM_THROTTLE_MS);
 			}
 		}
 
@@ -207,7 +211,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		if (expiringSoonPositions.length > 0) {
 			this.telegramState.positionsExpiringSoon = Date.now();
 			for (const p of expiringSoonPositions) {
-				this.sendMessageAll(PositionExpiringSoonMessage(p));
+				await this.sendMessageAll(PositionExpiringSoonMessage(p));
+				await this.sleep(TELEGRAM_THROTTLE_MS);
 			}
 		}
 
@@ -225,7 +230,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		if (expiredPositions.length > 0) {
 			this.telegramState.positionsExpired = Date.now();
 			for (const p of expiredPositions) {
-				this.sendMessageAll(PositionExpiredMessage(p));
+				await this.sendMessageAll(PositionExpiredMessage(p));
+				await this.sleep(TELEGRAM_THROTTLE_MS);
 			}
 		} else {
 			// @dev: fixes issue if ponder indexes and stateDate didnt change,
@@ -251,7 +257,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		if (phase2Positions.length > 0) {
 			this.telegramState.positionsPhase2 = Date.now();
 			for (const p of phase2Positions) {
-				this.sendMessageAll(PositionPhase2Message(p));
+				await this.sendMessageAll(PositionPhase2Message(p));
+				await this.sleep(TELEGRAM_THROTTLE_MS);
 			}
 		} else {
 			// Self-heal stale state (same pattern as positionsExpired)
@@ -410,5 +417,9 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		this.sendMessage(group, `You are not subscribed anymore.`);
 
 		this.writeBackupGroups();
+	}
+
+	private sleep(ms: number): Promise<void> {
+		return new Promise((resolve) => setTimeout(resolve, ms));
 	}
 }

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -46,6 +46,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		private readonly challenge: ChallengesService
 	) {
 		const time: number = Date.now() + 365 * 24 * 60 * 60 * 1000;
+		// @dev: expiration-related state must use service-startup time, not the +365d future
+		// default. Expirations are absolute timestamps; a future-init would skip alerts for
+		// any position whose expiration falls before that future date (i.e. all of them).
+		const startUpTime: number = Date.now();
 
 		this.telegramState = {
 			minterApplied: time,
@@ -53,8 +57,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			leadrateProposal: time,
 			leadrateChanged: time,
 			positions: time,
-			positionsExpiringSoon: time,
-			positionsExpired: time,
+			positionsExpiringSoon: startUpTime,
+			positionsExpired: startUpTime,
 			challenges: time,
 			bids: time,
 		};

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -23,6 +23,8 @@ import { MinterProposalVetoedMessage } from './messages/MinterProposalVetoed.mes
 import { MintingUpdateMessage } from './messages/MintingUpdate.message';
 import { PositionExpiredMessage } from './messages/PositionExpired.message';
 import { PositionExpiringSoonMessage } from './messages/PositionExpiringSoon.message';
+import { PositionMiniLifetimeMessage } from './messages/PositionMiniLifetime.message';
+import { PositionPhase2Message } from './messages/PositionPhase2.message';
 import { PositionProposalMessage } from './messages/PositionProposal.message';
 import { SavingUpdateMessage } from './messages/SavingUpdate.message';
 import { StablecoinBridgeMessage } from './messages/StablecoinBridgeUpdate.message';
@@ -57,8 +59,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			leadrateProposal: time,
 			leadrateChanged: time,
 			positions: time,
+			positionsMiniLifetime: startUpTime,
 			positionsExpiringSoon: startUpTime,
 			positionsExpired: startUpTime,
+			positionsPhase2: startUpTime,
 			challenges: time,
 			bids: time,
 		};
@@ -172,8 +176,25 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			}
 		}
 
-		// Positions expiring soon (within 24 hours)
+		// Mini-lifetime clones — created since last alert with sub-day lifetime.
+		// Matches the WFPS forced-sale attack vector (36-second clone).
 		const openPositions = Object.values(this.position.getPositionsOpen().map);
+		const miniLifetimeThreshold = 24 * 60 * 60; // 1 day, in seconds (position timestamps are seconds)
+		const miniLifetimePositions = openPositions.filter((p) => {
+			const stateDate = this.telegramState.positionsMiniLifetime;
+			const lifetime = p.expiration - p.created;
+			const isMini = lifetime < miniLifetimeThreshold;
+			const isNew = isMini && p.created * 1000 > stateDate;
+			return isMini && isNew;
+		});
+		if (miniLifetimePositions.length > 0) {
+			this.telegramState.positionsMiniLifetime = Date.now();
+			for (const p of miniLifetimePositions) {
+				this.sendMessageAll(PositionMiniLifetimeMessage(p));
+			}
+		}
+
+		// Positions expiring soon (within 24 hours)
 		const expiringSoonPositions = openPositions.filter((p) => {
 			const stateDate = new Date(this.telegramState.positionsExpiringSoon).getTime();
 			const warningDays = 1 * 24 * 60 * 60 * 1000;
@@ -206,6 +227,29 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			// reset to last 1h
 			if (Date.now() - this.telegramState.positionsExpired > 60 * 60 * 1000) {
 				this.telegramState.positionsExpired = Date.now() - 5 * 60 * 1000; // reduce 5min to allow latest expiration
+			}
+		}
+
+		// Forced-sale phase 2 entry — actionable arbitrage window (1× → 0× liq-price)
+		// where a defender can call buyExpiredCollateral before the equity reserve covers the loss.
+		const phase2Positions = openPositions.filter((p) => {
+			if (BigInt(p.principal || '0') === 0n) return false;
+			const stateDate = this.telegramState.positionsPhase2;
+			const phase2EntryMs = (p.expiration + p.challengePeriod) * 1000;
+			const phase2EndMs = (p.expiration + p.challengePeriod * 2) * 1000;
+			const inPhase2 = phase2EntryMs < Date.now() && Date.now() < phase2EndMs;
+			const isNew = inPhase2 && stateDate < phase2EntryMs;
+			return inPhase2 && isNew;
+		});
+		if (phase2Positions.length > 0) {
+			this.telegramState.positionsPhase2 = Date.now();
+			for (const p of phase2Positions) {
+				this.sendMessageAll(PositionPhase2Message(p));
+			}
+		} else {
+			// Self-heal stale state (same pattern as positionsExpired)
+			if (Date.now() - this.telegramState.positionsPhase2 > 60 * 60 * 1000) {
+				this.telegramState.positionsPhase2 = Date.now() - 5 * 60 * 1000;
 			}
 		}
 

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -21,6 +21,8 @@ import { LeadrateProposalMessage } from './messages/LeadrateProposal.message';
 import { MinterProposalMessage } from './messages/MinterProposal.message';
 import { MinterProposalVetoedMessage } from './messages/MinterProposalVetoed.message';
 import { MintingUpdateMessage } from './messages/MintingUpdate.message';
+import { PositionExpiredMessage } from './messages/PositionExpired.message';
+import { PositionExpiringSoonMessage } from './messages/PositionExpiringSoon.message';
 import { PositionProposalMessage } from './messages/PositionProposal.message';
 import { SavingUpdateMessage } from './messages/SavingUpdate.message';
 import { StablecoinBridgeMessage } from './messages/StablecoinBridgeUpdate.message';
@@ -51,6 +53,8 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			leadrateProposal: time,
 			leadrateChanged: time,
 			positions: time,
+			positionsExpiringSoon: time,
+			positionsExpired: time,
 			challenges: time,
 			bids: time,
 		};
@@ -161,6 +165,43 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			this.telegramState.positions = Date.now();
 			for (const p of requestedPosition) {
 				this.sendMessageAll(PositionProposalMessage(p));
+			}
+		}
+
+		// Positions expiring soon (within 24 hours)
+		const openPositions = Object.values(this.position.getPositionsOpen().map);
+		const expiringSoonPositions = openPositions.filter((p) => {
+			const stateDate = new Date(this.telegramState.positionsExpiringSoon).getTime();
+			const warningDays = 1 * 24 * 60 * 60 * 1000;
+			const isSoon = p.expiration * 1000 < Date.now() + warningDays;
+			const isNew = isSoon && stateDate + warningDays < p.expiration * 1000;
+			return isSoon && isNew;
+		});
+		if (expiringSoonPositions.length > 0) {
+			this.telegramState.positionsExpiringSoon = Date.now();
+			for (const p of expiringSoonPositions) {
+				this.sendMessageAll(PositionExpiringSoonMessage(p));
+			}
+		}
+
+		// Positions expired
+		const expiredPositions = openPositions.filter((p) => {
+			const stateDate = new Date(this.telegramState.positionsExpired).getTime();
+			const isExpired = p.expiration * 1000 < Date.now();
+			const isNew = isExpired && stateDate < p.expiration * 1000;
+			return isExpired && isNew;
+		});
+		if (expiredPositions.length > 0) {
+			this.telegramState.positionsExpired = Date.now();
+			for (const p of expiredPositions) {
+				this.sendMessageAll(PositionExpiredMessage(p));
+			}
+		} else {
+			// @dev: fixes issue if ponder indexes and stateDate didnt change,
+			// it might happen that an old state will trigger this due to re-indexing
+			// reset to last 1h
+			if (Date.now() - this.telegramState.positionsExpired > 60 * 60 * 1000) {
+				this.telegramState.positionsExpired = Date.now() - 5 * 60 * 1000; // reduce 5min to allow latest expiration
 			}
 		}
 

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -239,7 +239,7 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			if (BigInt(p.principal || '0') === 0n) return false;
 			const stateDate = this.telegramState.positionsPhase2;
 			const phase2EntryMs = (p.expiration + p.challengePeriod) * 1000;
-			const inDecayWindow = phase2EntryMs < Date.now();
+			const inDecayWindow = phase2EntryMs <= Date.now(); // inclusive — match monitoring's `timePassed >= cP`
 			const isNew = inDecayWindow && stateDate < phase2EntryMs;
 			return inDecayWindow && isNew;
 		});

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -48,10 +48,12 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		private readonly challenge: ChallengesService
 	) {
 		const time: number = Date.now() + 365 * 24 * 60 * 60 * 1000;
-		// @dev: expiration-related state must use service-startup time, not the +365d future
-		// default. Expirations are absolute timestamps; a future-init would skip alerts for
-		// any position whose expiration falls before that future date (i.e. all of them).
-		const startUpTime: number = Date.now();
+		// @dev: position-lifecycle state initialised to epoch (0). Expirations are absolute
+		// timestamps; a future-init would skip alerts for any position whose actionable
+		// timestamp is before init (incl. positions already in the actionable state at
+		// service start, e.g. after a restart during an in-flight attack — exactly the
+		// scenario the alerts exist to cover). With 0, the first cycle fires for every
+		// currently actionable position, then stateDate advances normally.
 
 		this.telegramState = {
 			minterApplied: time,
@@ -59,10 +61,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			leadrateProposal: time,
 			leadrateChanged: time,
 			positions: time,
-			positionsMiniLifetime: startUpTime,
-			positionsExpiringSoon: startUpTime,
-			positionsExpired: startUpTime,
-			positionsPhase2: startUpTime,
+			positionsMiniLifetime: 0,
+			positionsExpiringSoon: 0,
+			positionsExpired: 0,
+			positionsPhase2: 0,
 			challenges: time,
 			bids: time,
 		};

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -209,8 +209,9 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			}
 		}
 
-		// Positions expired
+		// Positions expired (only those with outstanding principal — clean exits are not actionable)
 		const expiredPositions = openPositions.filter((p) => {
+			if (BigInt(p.principal || '0') === 0n) return false;
 			const stateDate = new Date(this.telegramState.positionsExpired).getTime();
 			const isExpired = p.expiration * 1000 < Date.now();
 			const isNew = isExpired && stateDate < p.expiration * 1000;
@@ -232,14 +233,15 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 
 		// Forced-sale phase 2 entry — actionable arbitrage window (1× → 0× liq-price)
 		// where a defender can call buyExpiredCollateral before the equity reserve covers the loss.
+		// No upper bound: post-decay (price = 0) is still actionable — anyone can take collateral
+		// for free and trigger coverLoss; the operator should still be alerted.
 		const phase2Positions = openPositions.filter((p) => {
 			if (BigInt(p.principal || '0') === 0n) return false;
 			const stateDate = this.telegramState.positionsPhase2;
 			const phase2EntryMs = (p.expiration + p.challengePeriod) * 1000;
-			const phase2EndMs = (p.expiration + p.challengePeriod * 2) * 1000;
-			const inPhase2 = phase2EntryMs < Date.now() && Date.now() < phase2EndMs;
-			const isNew = inPhase2 && stateDate < phase2EntryMs;
-			return inPhase2 && isNew;
+			const inDecayWindow = phase2EntryMs < Date.now();
+			const isNew = inDecayWindow && stateDate < phase2EntryMs;
+			return inDecayWindow && isNew;
 		});
 		if (phase2Positions.length > 0) {
 			this.telegramState.positionsPhase2 = Date.now();

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -51,12 +51,6 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		private readonly challenge: ChallengesService
 	) {
 		const time: number = Date.now() + 365 * 24 * 60 * 60 * 1000;
-		// @dev: position-lifecycle state initialised to epoch (0). Expirations are absolute
-		// timestamps; a future-init would skip alerts for any position whose actionable
-		// timestamp is before init (incl. positions already in the actionable state at
-		// service start, e.g. after a restart during an in-flight attack — exactly the
-		// scenario the alerts exist to cover). With 0, the first cycle fires for every
-		// currently actionable position, then stateDate advances normally.
 
 		this.telegramState = {
 			minterApplied: time,
@@ -64,10 +58,6 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			leadrateProposal: time,
 			leadrateChanged: time,
 			positions: time,
-			positionsMiniLifetime: 0,
-			positionsExpiringSoon: 0,
-			positionsExpired: 0,
-			positionsPhase2: 0,
 			challenges: time,
 			bids: time,
 		};
@@ -77,6 +67,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			createdAt: time,
 			updatedAt: time,
 			groups: [],
+			alertedMiniLifetime: [],
+			alertedExpiringSoon: [],
+			alertedExpired: [],
+			alertedPhase2: [],
 		};
 	}
 
@@ -181,90 +175,77 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			}
 		}
 
-		// Mini-lifetime clones — created since last alert with sub-day lifetime.
-		// Matches the WFPS forced-sale attack vector (36-second clone).
+		// Position-lifecycle alerts use per-address dedup (alerted* arrays in
+		// telegramGroupState, persisted via writeBackupGroups). Compared to a single
+		// stateDate timestamp this correctly handles: service restart with already-
+		// actionable positions, telegram outage (positions stay un-listed until delivered),
+		// ponder reorg/back-fill, and partial group delivery.
 		const openPositions = Object.values(this.position.getPositionsOpen().map);
 		const miniLifetimeThreshold = 24 * 60 * 60; // 1 day, in seconds (position timestamps are seconds)
+		const warningWindowMs = 24 * 60 * 60 * 1000;
+
+		// Mini-lifetime clones — sub-day (expiration - created) lifetime, the WFPS attack pattern.
 		const miniLifetimePositions = openPositions.filter((p) => {
-			const stateDate = this.telegramState.positionsMiniLifetime;
-			const lifetime = p.expiration - p.created;
-			const isMini = lifetime < miniLifetimeThreshold;
-			const isNew = isMini && p.created * 1000 > stateDate;
-			return isMini && isNew;
+			if (this.telegramGroupState.alertedMiniLifetime.includes(p.position.toLowerCase())) return false;
+			return p.expiration - p.created < miniLifetimeThreshold;
 		});
-		if (miniLifetimePositions.length > 0) {
-			this.telegramState.positionsMiniLifetime = Date.now();
-			for (const p of miniLifetimePositions) {
-				await this.sendMessageAll(PositionMiniLifetimeMessage(p));
-				await this.sleep(TELEGRAM_THROTTLE_MS);
+		for (const p of miniLifetimePositions) {
+			const delivered = await this.sendMessageAll(PositionMiniLifetimeMessage(p));
+			if (delivered) {
+				this.telegramGroupState.alertedMiniLifetime.push(p.position.toLowerCase());
+				await this.writeBackupGroups();
 			}
+			await this.sleep(TELEGRAM_THROTTLE_MS);
 		}
 
-		// Positions expiring soon (within 24 hours)
+		// Positions expiring within the next warning window.
 		const expiringSoonPositions = openPositions.filter((p) => {
-			const stateDate = new Date(this.telegramState.positionsExpiringSoon).getTime();
-			const warningDays = 1 * 24 * 60 * 60 * 1000;
-			const isSoon = p.expiration * 1000 < Date.now() + warningDays;
-			const isNew = isSoon && stateDate + warningDays < p.expiration * 1000;
-			return isSoon && isNew;
+			if (this.telegramGroupState.alertedExpiringSoon.includes(p.position.toLowerCase())) return false;
+			return p.expiration * 1000 < Date.now() + warningWindowMs;
 		});
-		if (expiringSoonPositions.length > 0) {
-			this.telegramState.positionsExpiringSoon = Date.now();
-			for (const p of expiringSoonPositions) {
-				await this.sendMessageAll(PositionExpiringSoonMessage(p));
-				await this.sleep(TELEGRAM_THROTTLE_MS);
+		for (const p of expiringSoonPositions) {
+			const delivered = await this.sendMessageAll(PositionExpiringSoonMessage(p));
+			if (delivered) {
+				this.telegramGroupState.alertedExpiringSoon.push(p.position.toLowerCase());
+				await this.writeBackupGroups();
 			}
+			await this.sleep(TELEGRAM_THROTTLE_MS);
 		}
 
-		// Positions expired (only those with outstanding principal — clean exits are not actionable)
-		// Skip if already in phase 2: the phase-2 watcher fires in the same cycle with more
-		// actionable info (decay status), no need to double-alert.
+		// Positions expired with outstanding principal — clean exits are not actionable.
+		// Skip if already in phase 2: the phase-2 watcher fires for it instead.
 		const expiredPositions = openPositions.filter((p) => {
+			if (this.telegramGroupState.alertedExpired.includes(p.position.toLowerCase())) return false;
 			if (BigInt(p.principal || '0') === 0n) return false;
-			const stateDate = new Date(this.telegramState.positionsExpired).getTime();
 			const isExpired = p.expiration * 1000 < Date.now();
 			const alreadyInPhase2 = (p.expiration + p.challengePeriod) * 1000 <= Date.now();
-			const isNew = isExpired && stateDate < p.expiration * 1000;
-			return isExpired && isNew && !alreadyInPhase2;
+			return isExpired && !alreadyInPhase2;
 		});
-		if (expiredPositions.length > 0) {
-			this.telegramState.positionsExpired = Date.now();
-			for (const p of expiredPositions) {
-				await this.sendMessageAll(PositionExpiredMessage(p));
-				await this.sleep(TELEGRAM_THROTTLE_MS);
+		for (const p of expiredPositions) {
+			const delivered = await this.sendMessageAll(PositionExpiredMessage(p));
+			if (delivered) {
+				this.telegramGroupState.alertedExpired.push(p.position.toLowerCase());
+				await this.writeBackupGroups();
 			}
-		} else {
-			// @dev: fixes issue if ponder indexes and stateDate didnt change,
-			// it might happen that an old state will trigger this due to re-indexing
-			// reset to last 1h
-			if (Date.now() - this.telegramState.positionsExpired > 60 * 60 * 1000) {
-				this.telegramState.positionsExpired = Date.now() - 5 * 60 * 1000; // reduce 5min to allow latest expiration
-			}
+			await this.sleep(TELEGRAM_THROTTLE_MS);
 		}
 
-		// Forced-sale phase 2 entry — actionable arbitrage window (1× → 0× liq-price)
-		// where a defender can call buyExpiredCollateral before the equity reserve covers the loss.
-		// No upper bound: post-decay (price = 0) is still actionable — anyone can take collateral
-		// for free and trigger coverLoss; the operator should still be alerted.
+		// Forced-sale phase 2 — actionable arbitrage window (1× → 0× liq-price). No upper
+		// bound: post-decay (price = 0) is still actionable, anyone can take collateral for
+		// free and trigger coverLoss; the operator should still be alerted.
 		const phase2Positions = openPositions.filter((p) => {
+			if (this.telegramGroupState.alertedPhase2.includes(p.position.toLowerCase())) return false;
 			if (BigInt(p.principal || '0') === 0n) return false;
-			const stateDate = this.telegramState.positionsPhase2;
 			const phase2EntryMs = (p.expiration + p.challengePeriod) * 1000;
-			const inDecayWindow = phase2EntryMs <= Date.now(); // inclusive — match monitoring's `timePassed >= cP`
-			const isNew = inDecayWindow && stateDate < phase2EntryMs;
-			return inDecayWindow && isNew;
+			return phase2EntryMs <= Date.now(); // inclusive — match monitoring's `timePassed >= cP`
 		});
-		if (phase2Positions.length > 0) {
-			this.telegramState.positionsPhase2 = Date.now();
-			for (const p of phase2Positions) {
-				await this.sendMessageAll(PositionPhase2Message(p));
-				await this.sleep(TELEGRAM_THROTTLE_MS);
+		for (const p of phase2Positions) {
+			const delivered = await this.sendMessageAll(PositionPhase2Message(p));
+			if (delivered) {
+				this.telegramGroupState.alertedPhase2.push(p.position.toLowerCase());
+				await this.writeBackupGroups();
 			}
-		} else {
-			// Self-heal stale state (same pattern as positionsExpired)
-			if (Date.now() - this.telegramState.positionsPhase2 > 60 * 60 * 1000) {
-				this.telegramState.positionsPhase2 = Date.now() - 5 * 60 * 1000;
-			}
+			await this.sleep(TELEGRAM_THROTTLE_MS);
 		}
 
 		// Challenges started
@@ -326,17 +307,27 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 		this.sendMessageAll(messageInfo[0], messageInfo[1]);
 	}
 
-	private async sendMessageAll(message: string, video?: string) {
-		if (this.telegramGroupState.groups.length == 0) return;
+	/**
+	 * Send to all groups. Returns true iff delivery succeeded to at least one group
+	 * (or there are no groups configured — nothing to deliver to). Callers that need
+	 * delivery confirmation (e.g. for per-address alert dedup) should check the return
+	 * value before marking the alert as sent.
+	 */
+	private async sendMessageAll(message: string, video?: string): Promise<boolean> {
+		if (this.telegramGroupState.groups.length == 0) return true;
+		let anyDelivered = false;
 		for (const group of this.telegramGroupState.groups) {
-			await this.sendMessage(group, message, video);
+			const ok = await this.sendMessage(group, message, video);
+			if (ok) anyDelivered = true;
 		}
+		return anyDelivered;
 	}
 
-	private async sendMessage(group: string | number, message: string, video?: string) {
+	private async sendMessage(group: string | number, message: string, video?: string): Promise<boolean> {
 		try {
 			this.logger.log(`Sending message to group id: ${group}`);
 			video ? await this.doSendVideo(group, message, video) : await this.doSendMessage(group, message);
+			return true;
 		} catch (error) {
 			const msg = {
 				notFound: 'chat not found',
@@ -360,6 +351,7 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 			} else {
 				this.logger.warn(error);
 			}
+			return false;
 		}
 	}
 

--- a/socialmedia/telegram/telegram.types.ts
+++ b/socialmedia/telegram/telegram.types.ts
@@ -1,14 +1,13 @@
-// @dev: timestamps of last trigger emits
+// @dev: timestamps of last trigger emits. Position-lifecycle events use per-address
+// dedup persisted in TelegramGroupState (alerted* arrays) instead of a single timestamp,
+// because a single timestamp cannot correctly handle: service restart with already-
+// actionable positions, telegram outage, ponder reorg/back-fill, or partial delivery.
 export type TelegramState = {
 	minterApplied: number;
 	minterVetoed: number;
 	leadrateProposal: number;
 	leadrateChanged: number;
 	positions: number;
-	positionsMiniLifetime: number;
-	positionsExpiringSoon: number;
-	positionsExpired: number;
-	positionsPhase2: number;
 	challenges: number;
 	bids: number;
 };
@@ -25,4 +24,8 @@ export type TelegramGroupState = {
 	createdAt: number;
 	updatedAt: number;
 	groups: string[];
+	alertedMiniLifetime: string[];
+	alertedExpiringSoon: string[];
+	alertedExpired: string[];
+	alertedPhase2: string[];
 };

--- a/socialmedia/telegram/telegram.types.ts
+++ b/socialmedia/telegram/telegram.types.ts
@@ -5,6 +5,8 @@ export type TelegramState = {
 	leadrateProposal: number;
 	leadrateChanged: number;
 	positions: number;
+	positionsExpiringSoon: number;
+	positionsExpired: number;
 	challenges: number;
 	bids: number;
 };

--- a/socialmedia/telegram/telegram.types.ts
+++ b/socialmedia/telegram/telegram.types.ts
@@ -5,8 +5,10 @@ export type TelegramState = {
 	leadrateProposal: number;
 	leadrateChanged: number;
 	positions: number;
+	positionsMiniLifetime: number;
 	positionsExpiringSoon: number;
 	positionsExpired: number;
+	positionsPhase2: number;
 	challenges: number;
 	bids: number;
 };

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -14,3 +14,24 @@ export const formatCurrency = (value: string | number, minimumFractionDigits = 2
 
 	return formatter.format(amount);
 };
+
+/**
+ * Sanitize untrusted strings before interpolating them into Telegram Markdown V1 messages.
+ *
+ * On-chain values like ERC-20 `name()` / `symbol()` are attacker-controlled. A token whose
+ * name is `*x*` or contains an unbalanced `[` will either be rendered as formatting or cause
+ * Telegram to reject the entire message with `Bad Request: can't parse entities` — silently
+ * dropping the alert. We replace the special chars with their fullwidth Unicode counterparts
+ * so the text reads naturally without breaking parsing.
+ */
+export const safeMarkdown = (value: string | undefined | null): string => {
+	if (!value) return '';
+	return value
+		.replace(/\*/g, '＊')
+		.replace(/_/g, '＿')
+		.replace(/`/g, '｀')
+		.replace(/\[/g, '［')
+		.replace(/\]/g, '］')
+		.replace(/\(/g, '（')
+		.replace(/\)/g, '）');
+};


### PR DESCRIPTION
## Summary

Ports the position-lifecycle watchers from upstream (Frankencoin-ZCHF/frankencoin-api [PR #32](https://github.com/Frankencoin-ZCHF/frankencoin-api/pull/32), later refined to a single 24h alert in commit 756b50a) which never made it into this fork.

The WFPS forced-sale attack on 2026-04-25 spent 46 hours between clone setup (with 36-second lifetime) and drain — and during that whole window the existing telegram service stayed silent. Reason: `doSendUpdates()` only emits PositionProposal / Challenge / Bid / Trade events. Position expirations are a passive state transition (no event), so nothing surfaces them today.

## What this adds

Two filters in `socialmedia/telegram/telegram.service.ts → doSendUpdates()`:

1. **`PositionExpiringSoon`** — fires once per position when `expiration < now + 24h`
2. **`PositionExpired`** — fires once per position when `expiration < now`, with the full forceSell decay schedule (10× → 1× → 0×) as concrete UTC timestamps

Both messages mirror the upstream layout, adjusted for:
- dEURO V2/V3 only (no V1 challenge body)
- `principal` instead of `minted` (the field name on `PositionQuery` in this codebase)
- Currency label dEURO instead of ZCHF

State dedup via two new fields on `TelegramState` (`positionsExpiringSoon`, `positionsExpired`) — same in-memory pattern the upstream uses.

## Test plan

- [x] `yarn build` clean
- [ ] Deploy to dev, wait for next cycle — confirm no spurious alerts (no V3 position is currently within 24h of expiration; nearest is 138 days out)
- [ ] Sanity check on dev: temporarily lower the `warningDays` to e.g. 365 days → expect alerts for the 27 open positions → revert
- [ ] Promote to prod after one quiet cycle on dev

## Out of scope

- Mini-lifetime / phase-2 decay watchers — those go into `d-EURO/monitoring` (separate PR there)
- Smart-contract changes (min lifetime check in `clone()`) — separate concern

## Reference

Upstream PR: https://github.com/Frankencoin-ZCHF/frankencoin-api/pull/32