### PR TITLE
Redact secrets in bootstrap config log

### DIFF
--- a/api.config.ts
+++ b/api.config.ts
@@ -63,10 +63,25 @@ export const CONFIG: ConfigType = {
 	},
 };
 
+function redactConfig(config: ConfigType): ConfigType {
+	return {
+		...config,
+		coingeckoApiKey: '***',
+		network: { mainnet: '***', polygon: '***' },
+		telegram: { ...config.telegram, botToken: '***' },
+		twitter: {
+			...config.twitter,
+			clientSecret: '***',
+			appKey: '***',
+			appSecret: '***',
+		},
+	};
+}
+
 export function logConfig() {
 	const logger = new Logger('ApiConfig');
 	logger.log(`Starting API with this config:`);
-	logger.log(JSON.stringify(CONFIG));
+	logger.log(JSON.stringify(redactConfig(CONFIG)));
 }
 
 // Refer to https://github.com/yagop/node-telegram-bot-api/blob/master/doc/usage.md#sending-files

--- a/api.config.ts
+++ b/api.config.ts
@@ -63,19 +63,31 @@ export const CONFIG: ConfigType = {
 	},
 };
 
-function redactConfig(config: ConfigType): ConfigType {
-	return {
-		...config,
-		coingeckoApiKey: '***',
-		network: { mainnet: '***', polygon: '***' },
-		telegram: { ...config.telegram, botToken: '***' },
-		twitter: {
-			...config.twitter,
-			clientSecret: '***',
-			appKey: '***',
-			appSecret: '***',
-		},
-	};
+const SENSITIVE_KEYS = new Set<string>([
+	'coingeckoApiKey',
+	'network.mainnet',
+	'network.polygon',
+	'telegram.botToken',
+	'twitter.clientSecret',
+	'twitter.appKey',
+	'twitter.appSecret',
+]);
+
+function redactConfig<T>(config: T): T {
+	return walkRedact(config, '') as T;
+}
+
+function walkRedact(value: unknown, path: string): unknown {
+	if (value && typeof value === 'object' && !Array.isArray(value)) {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>).map(([key, val]) => {
+				const childPath = path ? `${path}.${key}` : key;
+				if (SENSITIVE_KEYS.has(childPath) && val) return [key, '***'];
+				return [key, walkRedact(val, childPath)];
+			})
+		);
+	}
+	return value;
 }
 
 export function logConfig() {


### PR DESCRIPTION
## Summary

- Avoid serializing sensitive config fields in the bootstrap log produced by `logConfig()`.
- Adds a small `redactConfig()` helper driven by an explicit `SENSITIVE_KEYS` set with dot-path entries; matching values are replaced with `***` before `JSON.stringify`.

## Test plan

- [ ] `npm run build` clean
- [ ] Container-Log nach Start zeigt `***` für die als sensitiv markierten Felder