### PR TITLE
Initialise /app/.api with node:node ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:lts-alpine
 
-RUN mkdir /app && chown -R node:node /app
+# Pre-create /app/.api so the telegram/twitter persistence dir inherits node:node
+# ownership when bind-mounted as a Docker volume. Without this, Docker initialises
+# the volume as root:root and the container — running as `node` — cannot persist
+# subscriber state via writeBackupGroups() (manifests as `Telegram group backup
+# failed` on every /subscribe, with no telegram.groups.json ever written).
+RUN mkdir -p /app/.api && chown -R node:node /app
 
 WORKDIR /app
 USER node


### PR DESCRIPTION
## Summary

The api container runs as the `node` user (uid 1000) but the `.api` persistence directory (`telegram.groups.json`, `twitter.token.json`) was never explicitly created in the image. When mounted as a Docker named volume the runtime path is initialised as `root:root drwxr-xr-x` and `writeBackupGroups()` fails with EACCES on every `/subscribe`:

```
info  [TelegramService]: Sending message to group id: ...
error [TelegramService]: Telegram group backup failed
```

`telegram.groups.json` is never written, so the bot never delivers any alert and the subscribe state is lost on every reload.

This PR pre-creates `/app/.api` in the image with `node:node` ownership so fresh volumes inherit the correct permissions on first mount.

### Existing volumes

Already-initialised volumes on dfxprd / dfxdev still own as `root:root` and need a one-off correction. That is handled separately via a one-shot init container in the DFXswiss/server compose stack so this image change stays minimal and fully repo-local.

## Test plan

- [ ] On a fresh deployment / fresh volume: confirm `/app/.api` is `node:node` and `/subscribe` writes `telegram.groups.json` successfully (`Telegram group backup stored` in logs)
- [ ] On the existing dfxprd volume: after the deploy-stack init container runs once, `/subscribe` succeeds