### PR TITLE
Accept /start as a subscribe alias

### DIFF
--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -38,7 +38,7 @@ const TELEGRAM_THROTTLE_MS = 100;
 export class TelegramService implements OnModuleInit, SocialMediaFct {
 	private readonly logger = new Logger(this.constructor.name);
 	private readonly bot = new TelegramBot(CONFIG.telegram.botToken, { polling: true });
-	private readonly telegramHandles: string[] = ['/subscribe', '/unsubscribe', '/help'];
+	private readonly telegramHandles: string[] = ['/start', '/subscribe', '/unsubscribe', '/help'];
 	private readonly telegramState: TelegramState;
 	private telegramGroupState: TelegramGroupState;
 
@@ -395,10 +395,13 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 	private async sendSubscribeMessage(msg: TelegramBot.Message): Promise<void> {
 		const group = msg.chat.id.toString();
 		const isSubscribed = this.telegramGroupState.groups.find((g) => g === group);
-		if (isSubscribed) return;
+		if (isSubscribed) {
+			this.sendMessage(group, `You are already subscribed.`);
+			return;
+		}
 
 		this.telegramGroupState.groups.push(group);
-		this.sendMessage(group, `You are now subscribed.`);
+		this.sendMessage(group, `You are now subscribed. Use /unsubscribe to stop.`);
 
 		this.writeBackupGroups();
 	}
@@ -406,7 +409,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 	private async sendUnsubscribeMessage(msg: TelegramBot.Message): Promise<void> {
 		const group = msg.chat.id.toString();
 		const isSubscribed = this.telegramGroupState.groups.find((g) => g === group);
-		if (!isSubscribed) return;
+		if (!isSubscribed) {
+			this.sendMessage(group, `You are not subscribed.`);
+			return;
+		}
 
 		const newGroups = this.telegramGroupState.groups.filter((g) => g != group);
 		this.telegramGroupState.groups = newGroups;

--- a/socialmedia/telegram/telegram.service.ts
+++ b/socialmedia/telegram/telegram.service.ts
@@ -373,6 +373,10 @@ export class TelegramService implements OnModuleInit, SocialMediaFct {
 					this.sendHelpMessage(m);
 					break;
 
+				// Telegram's default first-contact button maps to /start, so accepting it as
+				// a subscribe alias gives users a one-click onboarding path. /subscribe stays
+				// as an explicit alias for users that already know the command.
+				case '/start':
 				case '/subscribe':
 					this.sendSubscribeMessage(m);
 					break;


### PR DESCRIPTION
## Summary

Telegram's first-contact button on a fresh chat sends `/start`, which the bot previously fell through silently. Mapping it to the same handler as `/subscribe` gives users one-click onboarding without losing the explicit `/subscribe` command for users that already know it.

## Test plan

- [ ] `npm run build` clean
- [ ] After deploy: send `/start` to the bot in a fresh private chat → bot replies `You are now subscribed.` and chat-id is persisted in `telegram.groups.json`
- [ ] Existing `/subscribe` workflow unchanged