### PR TITLE
Route CoinGecko via the in-cluster pricing proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ CONFIG_CHAIN=mainnet
 RPC_URL_MAINNET=https://eth-mainnet.g.alchemy.com/v2/[API-KEY]
 RPC_URL_POLYGON=https://polygon-mainnet.g.alchemy.com/v2/[API-KEY]
 
+# CoinGecko: set EITHER a base URL pointing at a fronting pricing proxy (which
+# injects the upstream key itself, recommended for in-cluster deployments) OR a
+# direct Pro key. Setting only COINGECKO_BASE_URL is the cleanest setup; setting
+# only COINGECKO_API_KEY routes through pro-api.coingecko.com directly.
+# COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
 COINGECKO_API_KEY=[API-KEY]
 
 TELEGRAM_BOT_TOKEN=[API-KEY]

--- a/api.config.ts
+++ b/api.config.ts
@@ -9,14 +9,20 @@ dotenv.config();
 // Verify environment
 if (process.env.RPC_URL_MAINNET === undefined) throw new Error('RPC_URL_MAINNET not available');
 if (process.env.RPC_URL_POLYGON === undefined) throw new Error('RPC_URL_POLYGON not available');
-if (process.env.COINGECKO_API_KEY === undefined) throw new Error('COINGECKO_API_KEY not available');
+// Either a key for direct Pro access OR a base URL for a fronting pricing proxy
+// must be set; otherwise the upstream CoinGecko calls are anonymous and fail
+// under load.
+if (!process.env.COINGECKO_API_KEY && !process.env.COINGECKO_BASE_URL) {
+	throw new Error('COINGECKO_API_KEY or COINGECKO_BASE_URL must be set');
+}
 
 // Config type
 export type ConfigType = {
 	app: string;
 	indexer: string;
 	indexerFallback: string;
-	coingeckoApiKey: string;
+	coingeckoApiKey: string | undefined;
+	coingeckoBaseUrl: string | undefined;
 	chain: Chain;
 	network: {
 		mainnet: string;
@@ -42,7 +48,8 @@ export const CONFIG: ConfigType = {
 	app: process.env.CONFIG_APP_URL || 'https://app.deuro.com',
 	indexer: process.env.CONFIG_INDEXER_URL || 'https://ponder.deuro.com/',
 	indexerFallback: process.env.CONFIG_INDEXER_FALLBACK_URL || 'https://dev.ponder.deuro.com/',
-	coingeckoApiKey: process.env.COINGECKO_API_KEY,
+	coingeckoApiKey: process.env.COINGECKO_API_KEY || undefined,
+	coingeckoBaseUrl: process.env.COINGECKO_BASE_URL || undefined,
 	chain: process.env.CONFIG_CHAIN === 'polygon' ? polygon : mainnet, // @dev: default mainnet
 	network: {
 		mainnet: process.env.RPC_URL_MAINNET,
@@ -112,10 +119,21 @@ export const VIEM_CONFIG = createPublicClient({
 });
 
 // COINGECKO CLIENT
+//
+// Resolution priority:
+//  1. COINGECKO_BASE_URL set → trust the caller (typically a pricing proxy that
+//     injects the upstream key itself); send no auth.
+//  2. COINGECKO_API_KEY set → Pro tier: pro-api.coingecko.com with the
+//     `x-cg-pro-api-key` header. The earlier query-string form is supported by
+//     CoinGecko but cache-poisons proxies that key on the URL.
 export const COINGECKO_CLIENT = (query: string) => {
-	const hasParams = query.includes('?');
+	if (CONFIG.coingeckoBaseUrl) {
+		return fetch(`${CONFIG.coingeckoBaseUrl}${query}`);
+	}
 	const uri: string = `https://pro-api.coingecko.com${query}`;
-	return fetch(`${uri}${hasParams ? '&' : '?'}x_cg_pro_api_key=${CONFIG.coingeckoApiKey}`);
+	return fetch(uri, {
+		headers: { 'x-cg-pro-api-key': CONFIG.coingeckoApiKey ?? '' },
+	});
 };
 
 // Contract addresses for the active chain


### PR DESCRIPTION
## Summary
- The api always called \`pro-api.coingecko.com\` directly with a query-string-keyed Pro key. That works on its own but cache-poisons any HTTP-cache that keys on the URL, and it bypasses the central pricing proxy that already holds the upstream key, runs a 60 s shared cache, and validates upstream error envelopes.
- New \`COINGECKO_BASE_URL\` env var: when set, requests go to that origin (typically the pricing proxy) and no auth header is added — the proxy injects the key.
- \`COINGECKO_API_KEY\` remains supported as a direct fallback. Calls now route to \`pro-api.coingecko.com\` via the \`x-cg-pro-api-key\` header instead of the cache-unfriendly \`x_cg_pro_api_key\` query string.
- Bootstrap requires at least one of the two so the service does not silently come up unauthenticated.

## Resolution priority
1. \`COINGECKO_BASE_URL\` set → proxy mode, no key sent from this service.
2. \`COINGECKO_API_KEY\` set → \`pro-api.coingecko.com\` + \`x-cg-pro-api-key\` header.

## Test plan
- [ ] Build (\`npm run build\`) passes locally.
- [ ] Deploy to dev with \`COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko\` and no \`COINGECKO_API_KEY\` — confirm price fetches still log success.
- [ ] Backwards compat: with only \`COINGECKO_API_KEY\` set, confirm calls still resolve via \`pro-api.coingecko.com\`.
- [ ] Bootstrap: starting the api with neither var set must throw \`COINGECKO_API_KEY or COINGECKO_BASE_URL must be set\`.