### PR TITLE
Drop the empty-string fallback on the Pro API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,18 @@ CONFIG_CHAIN=mainnet
 RPC_URL_MAINNET=https://eth-mainnet.g.alchemy.com/v2/[API-KEY]
 RPC_URL_POLYGON=https://polygon-mainnet.g.alchemy.com/v2/[API-KEY]
 
-# CoinGecko: all upstream calls go through the in-cluster pricing proxy.
+# CoinGecko Configuration.
+#
+# COINGECKO_BASE_URL: required. The origin the api calls. Recommended is
+# the in-cluster pricing-proxy (https://github.com/DFXswiss/pricing-proxy),
+# which holds the upstream Pro key and serves a 60 s shared cache. Anything
+# CoinGecko-compatible works (pro-api.coingecko.com, api.coingecko.com, …).
 COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+#
+# COINGECKO_API_KEY: optional. If set, attached as `x-cg-pro-api-key` to
+# every request. Leave unset when talking to the pricing-proxy (proxy injects
+# its own key) or to the public host anonymously.
+# COINGECKO_API_KEY=
 
 TELEGRAM_BOT_TOKEN=[API-KEY]
 TELEGRAM_GROUPS_JSON=telegram.groups.json

--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,8 @@ CONFIG_CHAIN=mainnet
 RPC_URL_MAINNET=https://eth-mainnet.g.alchemy.com/v2/[API-KEY]
 RPC_URL_POLYGON=https://polygon-mainnet.g.alchemy.com/v2/[API-KEY]
 
-# CoinGecko: set EITHER a base URL pointing at a fronting pricing proxy (which
-# injects the upstream key itself, recommended for in-cluster deployments) OR a
-# direct Pro key. Setting only COINGECKO_BASE_URL is the cleanest setup; setting
-# only COINGECKO_API_KEY routes through pro-api.coingecko.com directly.
-# COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
-COINGECKO_API_KEY=[API-KEY]
+# CoinGecko: all upstream calls go through the in-cluster pricing proxy.
+COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
 
 TELEGRAM_BOT_TOKEN=[API-KEY]
 TELEGRAM_GROUPS_JSON=telegram.groups.json

--- a/README.md
+++ b/README.md
@@ -20,12 +20,44 @@ CONFIG_CHAIN=mainnet
 RPC_URL_MAINNET=https://eth-mainnet.g.alchemy.com/v2/[API-KEY]
 RPC_URL_POLYGON=https://polygon-mainnet.g.alchemy.com/v2/[API-KEY]
 
-COINGECKO_API_KEY=[API-KEY]
+# See "CoinGecko" section below.
+COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+# COINGECKO_API_KEY=
 
 TELEGRAM_BOT_TOKEN=[API-KEY]
 TELEGRAM_GROUPS_JSON=telegram.groups.json
 TELEGRAM_IMAGES_DIR=./images
 ```
+
+## CoinGecko
+
+The api fetches token prices from a CoinGecko-compatible endpoint.
+Configuration is two env vars:
+
+| Var | Required | Purpose |
+|---|---|---|
+| `COINGECKO_BASE_URL` | yes | Origin the api calls. |
+| `COINGECKO_API_KEY` | no | Attached as the `x-cg-pro-api-key` header on every request when set. |
+
+The recommended deployment is the
+[**pricing-proxy**](https://github.com/DFXswiss/pricing-proxy) — a small
+caching reverse-proxy in front of CoinGecko Pro. It holds the upstream
+key, serves a 60 s shared cache, validates upstream error envelopes, and
+coalesces concurrent identical requests. When you use the proxy:
+
+```env
+COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+# COINGECKO_API_KEY left unset — the proxy injects its own key
+```
+
+Without the proxy, talk to CoinGecko directly:
+
+```env
+COINGECKO_BASE_URL=https://pro-api.coingecko.com
+COINGECKO_API_KEY=CG-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+The api refuses to start without `COINGECKO_BASE_URL`.
 
 ## Running the app
 

--- a/api.config.ts
+++ b/api.config.ts
@@ -9,8 +9,11 @@ dotenv.config();
 // Verify environment
 if (process.env.RPC_URL_MAINNET === undefined) throw new Error('RPC_URL_MAINNET not available');
 if (process.env.RPC_URL_POLYGON === undefined) throw new Error('RPC_URL_POLYGON not available');
-// The api always talks to the in-cluster pricing proxy. The upstream Pro key
-// lives in the proxy stack, not here.
+// COINGECKO_BASE_URL is the origin the api calls — typically the in-cluster
+// pricing-proxy (https://github.com/DFXswiss/pricing-proxy), but any
+// CoinGecko-compatible host works. COINGECKO_API_KEY is optional and is
+// only attached as `x-cg-pro-api-key` on every request when set (proxy mode
+// leaves it unset because the proxy injects its own key).
 if (!process.env.COINGECKO_BASE_URL) {
 	throw new Error('COINGECKO_BASE_URL is not set');
 }
@@ -21,6 +24,7 @@ export type ConfigType = {
 	indexer: string;
 	indexerFallback: string;
 	coingeckoBaseUrl: string;
+	coingeckoApiKey: string | undefined;
 	chain: Chain;
 	network: {
 		mainnet: string;
@@ -47,6 +51,7 @@ export const CONFIG: ConfigType = {
 	indexer: process.env.CONFIG_INDEXER_URL || 'https://ponder.deuro.com/',
 	indexerFallback: process.env.CONFIG_INDEXER_FALLBACK_URL || 'https://dev.ponder.deuro.com/',
 	coingeckoBaseUrl: process.env.COINGECKO_BASE_URL,
+	coingeckoApiKey: process.env.COINGECKO_API_KEY || undefined,
 	chain: process.env.CONFIG_CHAIN === 'polygon' ? polygon : mainnet, // @dev: default mainnet
 	network: {
 		mainnet: process.env.RPC_URL_MAINNET,
@@ -68,6 +73,7 @@ export const CONFIG: ConfigType = {
 };
 
 const SENSITIVE_KEYS = new Set<string>([
+	'coingeckoApiKey',
 	'network.mainnet',
 	'network.polygon',
 	'telegram.botToken',
@@ -115,10 +121,20 @@ export const VIEM_CONFIG = createPublicClient({
 });
 
 // COINGECKO CLIENT
-// All CoinGecko traffic goes through the in-cluster pricing proxy. The proxy
-// holds the upstream key and validates upstream errors, so the api itself
-// never talks to pro-api.coingecko.com directly.
-export const COINGECKO_CLIENT = (query: string) => fetch(`${CONFIG.coingeckoBaseUrl}${query}`);
+//
+// Calls go to whatever `COINGECKO_BASE_URL` points at. When the optional
+// `COINGECKO_API_KEY` is set, it is attached as the `x-cg-pro-api-key`
+// header — orthogonal to the base URL, never a fallback. The recommended
+// deployment is the in-cluster pricing-proxy
+// (https://github.com/DFXswiss/pricing-proxy), which injects its own key
+// and leaves COINGECKO_API_KEY unset on every consumer.
+export const COINGECKO_CLIENT = (query: string) => {
+	const headers: Record<string, string> = { accept: 'application/json' };
+	if (CONFIG.coingeckoApiKey) {
+		headers['x-cg-pro-api-key'] = CONFIG.coingeckoApiKey;
+	}
+	return fetch(`${CONFIG.coingeckoBaseUrl}${query}`, { headers });
+};
 
 // Contract addresses for the active chain
 export const ADDR = ADDRESS[CONFIG.chain.id];

--- a/api.config.ts
+++ b/api.config.ts
@@ -9,11 +9,10 @@ dotenv.config();
 // Verify environment
 if (process.env.RPC_URL_MAINNET === undefined) throw new Error('RPC_URL_MAINNET not available');
 if (process.env.RPC_URL_POLYGON === undefined) throw new Error('RPC_URL_POLYGON not available');
-// Either a key for direct Pro access OR a base URL for a fronting pricing proxy
-// must be set; otherwise the upstream CoinGecko calls are anonymous and fail
-// under load.
-if (!process.env.COINGECKO_API_KEY && !process.env.COINGECKO_BASE_URL) {
-	throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
+// The api always talks to the in-cluster pricing proxy. The upstream Pro key
+// lives in the proxy stack, not here.
+if (!process.env.COINGECKO_BASE_URL) {
+	throw new Error('COINGECKO_BASE_URL is not set');
 }
 
 // Config type
@@ -21,8 +20,7 @@ export type ConfigType = {
 	app: string;
 	indexer: string;
 	indexerFallback: string;
-	coingeckoApiKey: string | undefined;
-	coingeckoBaseUrl: string | undefined;
+	coingeckoBaseUrl: string;
 	chain: Chain;
 	network: {
 		mainnet: string;
@@ -48,8 +46,7 @@ export const CONFIG: ConfigType = {
 	app: process.env.CONFIG_APP_URL || 'https://app.deuro.com',
 	indexer: process.env.CONFIG_INDEXER_URL || 'https://ponder.deuro.com/',
 	indexerFallback: process.env.CONFIG_INDEXER_FALLBACK_URL || 'https://dev.ponder.deuro.com/',
-	coingeckoApiKey: process.env.COINGECKO_API_KEY || undefined,
-	coingeckoBaseUrl: process.env.COINGECKO_BASE_URL || undefined,
+	coingeckoBaseUrl: process.env.COINGECKO_BASE_URL,
 	chain: process.env.CONFIG_CHAIN === 'polygon' ? polygon : mainnet, // @dev: default mainnet
 	network: {
 		mainnet: process.env.RPC_URL_MAINNET,
@@ -71,7 +68,6 @@ export const CONFIG: ConfigType = {
 };
 
 const SENSITIVE_KEYS = new Set<string>([
-	'coingeckoApiKey',
 	'network.mainnet',
 	'network.polygon',
 	'telegram.botToken',
@@ -119,30 +115,10 @@ export const VIEM_CONFIG = createPublicClient({
 });
 
 // COINGECKO CLIENT
-//
-// Resolution priority:
-//  1. COINGECKO_BASE_URL set → trust the caller (typically a pricing proxy that
-//     injects the upstream key itself); send no auth.
-//  2. COINGECKO_API_KEY set → Pro tier: pro-api.coingecko.com with the
-//     `x-cg-pro-api-key` header. The earlier query-string form is supported by
-//     CoinGecko but cache-poisons proxies that key on the URL.
-export const COINGECKO_CLIENT = (query: string) => {
-	if (CONFIG.coingeckoBaseUrl) {
-		return fetch(`${CONFIG.coingeckoBaseUrl}${query}`);
-	}
-	// Bootstrap above guarantees one of the two is set, so reaching this
-	// branch means coingeckoApiKey is defined. Hard-fail anyway instead of
-	// using a `?? ''` default — sending an empty auth header would silently
-	// turn into 401 at the upstream and look like a CoinGecko outage rather
-	// than the misconfiguration it actually is.
-	if (!CONFIG.coingeckoApiKey) {
-		throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
-	}
-	const uri: string = `https://pro-api.coingecko.com${query}`;
-	return fetch(uri, {
-		headers: { 'x-cg-pro-api-key': CONFIG.coingeckoApiKey },
-	});
-};
+// All CoinGecko traffic goes through the in-cluster pricing proxy. The proxy
+// holds the upstream key and validates upstream errors, so the api itself
+// never talks to pro-api.coingecko.com directly.
+export const COINGECKO_CLIENT = (query: string) => fetch(`${CONFIG.coingeckoBaseUrl}${query}`);
 
 // Contract addresses for the active chain
 export const ADDR = ADDRESS[CONFIG.chain.id];

--- a/api.config.ts
+++ b/api.config.ts
@@ -13,7 +13,7 @@ if (process.env.RPC_URL_POLYGON === undefined) throw new Error('RPC_URL_POLYGON 
 // must be set; otherwise the upstream CoinGecko calls are anonymous and fail
 // under load.
 if (!process.env.COINGECKO_API_KEY && !process.env.COINGECKO_BASE_URL) {
-	throw new Error('COINGECKO_API_KEY or COINGECKO_BASE_URL must be set');
+	throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
 }
 
 // Config type

--- a/api.config.ts
+++ b/api.config.ts
@@ -130,9 +130,17 @@ export const COINGECKO_CLIENT = (query: string) => {
 	if (CONFIG.coingeckoBaseUrl) {
 		return fetch(`${CONFIG.coingeckoBaseUrl}${query}`);
 	}
+	// Bootstrap above guarantees one of the two is set, so reaching this
+	// branch means coingeckoApiKey is defined. Hard-fail anyway instead of
+	// using a `?? ''` default — sending an empty auth header would silently
+	// turn into 401 at the upstream and look like a CoinGecko outage rather
+	// than the misconfiguration it actually is.
+	if (!CONFIG.coingeckoApiKey) {
+		throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
+	}
 	const uri: string = `https://pro-api.coingecko.com${query}`;
 	return fetch(uri, {
-		headers: { 'x-cg-pro-api-key': CONFIG.coingeckoApiKey ?? '' },
+		headers: { 'x-cg-pro-api-key': CONFIG.coingeckoApiKey },
 	});
 };
 


### PR DESCRIPTION
## Summary
Follow-up to #106. The pro-tier branch of \`COINGECKO_CLIENT\` carried \`'x-cg-pro-api-key': CONFIG.coingeckoApiKey ?? ''\`. The bootstrap check guarantees one of the two env vars is set, so an empty key would only reach this branch through a misconfiguration that escaped the bootstrap. The empty header then turns into an upstream 401 that looks like a CoinGecko outage instead of the local config problem it really is.

- Explicit throw if \`coingeckoApiKey\` reaches the branch undefined.
- Plain string assignment, no \`??\` default.

## Test plan
- [ ] \`npm run build\` passes.
- [ ] Boot with only \`COINGECKO_BASE_URL\` set → proxy path used, key branch unreached.
- [ ] Boot with only \`COINGECKO_API_KEY\` set → header sent as plain string.