### PR TITLE
Honor euro-price TTL inside updatePrices

### DIFF
--- a/prices/prices.service.ts
+++ b/prices/prices.service.ts
@@ -221,11 +221,7 @@ export class PricesService {
 	async updatePrices() {
 		this.logger.debug('Updating Prices');
 
-		const euroPrice = await this.fetchEuroPrice();
-		if (euroPrice) {
-			this.euroPrice = euroPrice;
-			this.euroPriceTimestamp = Date.now();
-		}
+		await this.refreshEuroPriceIfStale();
 
 		const deps = this.getDeps();
 		const m = this.getMint();


### PR DESCRIPTION
## Summary

- `PricesService.updatePrices()` fetched `simple/price?ids=tether&vs_currencies=eur,btc` on every invocation, bypassing the existing `EURO_PRICE_TTL` (60s) that `getEuroPrice()` and `getDepsPrice()` already honored via `refreshEuroPriceIfStale()`.
- Since `updatePrices()` is driven by `ApiService.updateWorkflow()` on every new block (`POLLING_DELAY` is 6s for mainnet, 12s for polygon), this generated 5-10x more upstream calls than the 60s cache window intended — enough to exhaust the monthly CoinGecko Pro quota.
- Replace the direct `fetchEuroPrice()` call with `refreshEuroPriceIfStale()` so the same TTL applies to every entry point.

## Test plan

- [ ] `yarn build` (note: existing TS errors in `savings/savings.core.service.ts` are pre-existing on `develop`, unrelated to this change)
- [ ] On a running instance: confirm the upstream call rate to the tether/eur endpoint drops to at most 1 per minute
- [ ] Verify `GET /prices/eur` continues to return a current rate