### PR TITLE
Stop refetching tokens without a price source on every block

### DIFF
--- a/prices/prices.service.ts
+++ b/prices/prices.service.ts
@@ -259,6 +259,9 @@ export class PricesService {
 
 				if (!price) {
 					pricesQueryUpdateCountFailed += 1;
+					// bump timestamp on failure so we honour the 5-minute retry window
+					// instead of refetching on every block tick when a token has no price source
+					pricesQuery[addr] = { ...oldEntry, timestamp: Date.now() };
 				} else {
 					pricesQuery[addr] = {
 						...erc,


### PR DESCRIPTION
## Summary

- Several collateral tokens have no CoinGecko listing — the endpoint returns `{}` (HTTP 200), `fetchSourcesCoingecko()` then returns `undefined`, and `updatePrices()` discards the result without touching the cache entry.
- Because the entry's `timestamp` never advances, `oldEntry.timestamp + 300_000 < Date.now()` stays true and `updatePrices()` retries the same token on every block tick (every 6–12 s via `ApiService.updateWorkflow`).
- The in-cluster pricing proxy absorbs most of that with its 60s cache, but one upstream MISS per minute per token still leaks through. With three unlisted tokens active across two API instances, that is ~300 upstream calls per hour — the largest remaining CoinGecko quota consumer after #110.
- Bump the entry's `timestamp` on a failed fetch as well, so a missing price obeys the same 5-minute retry window as a successful one.

## Test plan

- [ ] `yarn build` (note: existing TS errors in `savings/savings.core.service.ts` are pre-existing on `develop`, unrelated to this change)
- [ ] On a running instance: confirm the upstream call rate to `simple/token_price/ethereum?contract_addresses=…` for the unlisted-token addresses drops from ~50/h to ~12/h
- [ ] Verify `GET /prices/list` still returns those tokens (without a `price` field, as before)