### PR TITLE
fix: reclassify Apollo network-error log severity

### DIFF
--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -6,53 +6,47 @@ import { CONFIG } from './api.config';
 
 const logger = new Logger('ApiApolloConfig');
 
+const FALLBACK_WINDOW_MS = 10 * 60 * 1000;
 let fallbackUntil: number | null = null;
 
 function getIndexerUrl(): string {
-	return fallbackUntil && Date.now() < fallbackUntil 
-		? CONFIG.indexerFallback 
-		: CONFIG.indexer;
+	return fallbackUntil && Date.now() < fallbackUntil ? CONFIG.indexerFallback : CONFIG.indexer;
 }
 
 function activateFallback(): void {
-	if (!fallbackUntil) {
-		fallbackUntil = Date.now() + 10 * 60 * 1000;
+	// Re-arm when the previous window has expired so a sustained outage
+	// keeps the fallback engaged instead of silently flipping back to primary.
+	if ((!fallbackUntil || Date.now() >= fallbackUntil) && CONFIG.indexerFallback) {
+		fallbackUntil = Date.now() + FALLBACK_WINDOW_MS;
 		logger.log(`[Ponder] Switching to fallback for 10min: ${CONFIG.indexerFallback}`);
 	}
 }
 
 const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
+	const opName = operation?.operationName || 'unknown';
+
 	if (graphQLErrors) {
 		graphQLErrors.forEach((error) => {
-			logger.error(`[GraphQL error in operation: ${operation?.operationName || 'unknown'}]`, {
-				message: error.message,
-				locations: error.locations,
-				path: error.path,
-			});
+			logger.error(`[GraphQL error in operation: ${opName}] ${error.message}`);
 		});
 	}
-	
+
 	if (networkError) {
-		logger.error(`[Network error in operation: ${operation?.operationName || 'unknown'}]`, {
-			message: networkError.message,
-			name: networkError.name,
-			stack: networkError.stack,
-		});
+		const hasFallback = !!CONFIG.indexerFallback;
+		const onFallback = getIndexerUrl() !== CONFIG.indexer;
+		const willRecover = hasFallback && !onFallback;
+		const msg = `[Network error in operation: ${opName}] ${networkError.message}`;
 
-		if (getIndexerUrl() === CONFIG.indexer) {
-			const is503 =
-				(networkError as any)?.response?.status === 503 ||
-				(networkError as any)?.statusCode === 503 ||
-				(networkError as any)?.result?.status === 503;
-
-			if (is503) {
-				logger.log('[Ponder] 503 Service Unavailable - Ponder is syncing, switching to fallback');
-			} else {
-				logger.log('[Ponder] Network error detected, activating fallback');
-			}
+		if (willRecover) {
+			// Primary failed, fallback hasn't been engaged this window — log
+			// at warn so transparent retries don't inflate error-rate panels.
+			logger.warn(msg);
 			activateFallback();
 			return forward(operation);
 		}
+
+		// No fallback configured, or already on fallback — nothing more to try.
+		logger.error(msg);
 	}
 });
 
@@ -67,10 +61,9 @@ const httpLink = createHttpLink({
 		return fetch(uri, {
 			...options,
 			signal: controller.signal,
-		})
-			.finally(() => {
-				clearTimeout(timeout);
-			});
+		}).finally(() => {
+			clearTimeout(timeout);
+		});
 	},
 });
 


### PR DESCRIPTION
## Summary

Reclassify recoverable Apollo network errors from `error` to `warn` so the
transparent indexer-fallback retry path no longer inflates the dfxprd
error-rate panels. Also tighten the fallback window and drop log payload
fields that the active log formatter silently discards.

Tracked in [`DFXServer/server#278`](https://github.com/DFXServer/server/issues/278);
parallel PR for the sister codebase at
[`JuiceDollar/api#58`](https://github.com/JuiceDollar/api/pull/58).

## Investigation

Sampled `2026-06-01 ~11:00 CEST` on `dfxprd` (Loki):

| Container | error/60m | error/24h |
|---|---:|---:|
| `deuro-deuro-api-8` | 47 | 977 |

Every `error [ApiApolloConfig]: [Network error in operation: …]` line on
dfxprd is paired 1:1 with an `info [ApiApolloConfig]: [Ponder] Network
error detected, activating fallback` line — i.e. **every** error is the
recoverable transient-hiccup path, not a real outage. The system handles
them via `forward(operation)`, the user-facing request retries, but the
log entry already shipped at error severity.

GraphQL-errors path: **0/24h** on dfxprd — confirms the noise is purely
from the network-error path.

Two latent problems found while tracing this:

1. **Metadata payload was silently dropped.** The Winston formatter in
   `api.main.ts` is `format.printf((info) => \`${info.level} [${info.context}]: ${info.message}\`)`
   — it only reads `info.message`. The `{ message, name, stack }` second
   argument to `logger.error(...)` was never reaching Loki. Inlining
   `networkError.message` into the main string keeps the signal that
   was being silently lost.
2. **`activateFallback()` only armed once per process lifetime.** Guard
   was `if (!fallbackUntil)`, which stays falsy only until the first
   activation. After the 10-min window expires, the guard fails and
   `fallbackUntil` is never refreshed, so the "Switching to fallback"
   log fires exactly once per container boot (confirmed via Loki: 0
   matches in 24h despite ongoing activity).

## Change

```diff
 if (networkError) {
-    logger.error(`[Network error in operation: ${op}]`, { message, name, stack });
-
-    if (getIndexerUrl() === CONFIG.indexer) {
-        const is503 = ...;
-        if (is503) logger.log('[Ponder] 503 Service Unavailable - …');
-        else       logger.log('[Ponder] Network error detected, …');
-        activateFallback();
-        return forward(operation);
-    }
+    const hasFallback = !!CONFIG.indexerFallback;
+    const onFallback = getIndexerUrl() !== CONFIG.indexer;
+    const willRecover = hasFallback && !onFallback;
+    const msg = `[Network error in operation: ${op}] ${networkError.message}`;
+
+    if (willRecover) {
+        logger.warn(msg);
+        activateFallback();
+        return forward(operation);
+    }
+    logger.error(msg);
 }
```

Plus `activateFallback()` re-arm:

```diff
-if (!fallbackUntil) {
+if ((!fallbackUntil || Date.now() >= fallbackUntil) && CONFIG.indexerFallback) {
```

The `GraphQL error` branch loses its `{ locations, path }` payload for the
same reason (Winston discarded it) — `error.message` is appended to the
main string instead.

## Behaviour matrix

| Scenario | severity | retries? |
|---|---|---|
| Primary fails, fallback configured & different URL, first time | `warn` | yes, via fallback |
| Primary fails, fallback configured & different URL, already on fallback | `error` | no (propagate) |
| Primary fails, `CONFIG_INDEXER_FALLBACK_URL == CONFIG_INDEXER_URL` (current PRD) | `warn` | yes, same URL |
| Primary fails, no fallback URL configured | `error` | no |
| GraphQL error | `error` | no (unchanged) |

## Expected post-deploy effect on dfxprd

With the current `CONFIG_INDEXER_URL == CONFIG_INDEXER_FALLBACK_URL`
config (intentional, see compose comment about the prior PRD→DEV
traffic leak), `willRecover` evaluates to `true` for every network
error. So:

- `ApiApolloConfig` error-level lines from network errors: **~977/d → 0/d**
- `ApiApolloConfig` warn-level lines from network errors: **0/d → ~977/d**
- Residual error-level entries: graphQL-errors path only (0/24h baseline)

A real outage where the retry also fails still surfaces at error level
**if** a distinct fallback URL is configured. For PRD today (same-URL
fallback), real outages will show as elevated warn-rate; switching
fallback to a distinct indexer is a separate infra decision.

Verification query:

```logql
sum(count_over_time(
  {server="dfxprd", container_name="deuro-deuro-api-8"}
  | detected_level="error" |= "ApiApolloConfig" [60m]
))
```

## Test plan

- [x] `yarn build` clean (verified locally on the branch HEAD)
- [x] `yarn lint` clean (verified locally on the branch HEAD)
- [x] `npx prettier --check api.apollo.config.ts` clean
- [ ] After deploy to dfxprd: Loki error-rate for `deuro-deuro-api-8`
      `ApiApolloConfig` drops to ~0; warn-rate picks up the same volume.
- [ ] Verify `[Ponder] Switching to fallback for 10min: …` log emits
      on first activation per window (and re-emits after window expiry).