### PR TITLE
fix: guard fetchEuroPrice against a malformed coingecko response

### DIFF
--- a/prices/prices.service.ts
+++ b/prices/prices.service.ts
@@ -200,6 +200,10 @@ export class PricesService {
 			this.logger.debug(data.status?.error_message || 'Error fetching price from coingecko');
 			return null;
 		}
+		if (!data.tether || typeof data.tether.eur !== 'number' || typeof data.tether.btc !== 'number') {
+			this.logger.debug('Unexpected coingecko response shape fetching euro price');
+			return null;
+		}
 
 		return {
 			eur: 1,


### PR DESCRIPTION
## Summary
- `fetchEuroPrice()` checked `data.status` for CoinGecko's own error shape but never guarded `data.tether` itself being undefined/malformed — a bad 200 body throws `Cannot read properties of undefined (reading 'eur')`.
- Confirmed live on prod (`deuro-deuro-api-9`, `[ExceptionsHandler]: Cannot read properties of undefined (reading 'eur')`) a few times/day.
- Blast radius: the cron path (`updatePrices`) swallows this via `.catch(() => {})`, but `GET /prices/eur` and `GET /prices/deps` call the same function through `refreshEuroPriceIfStale()` with no try/catch — a real caller gets a 500.
- Mirrors the existing defensive check `fetchSourcesCoingeckoBatch` already uses for the same CoinGecko client.

## Test plan
- [x] `yarn build` — clean
- [x] `npx eslint prices/prices.service.ts` — no new issues (pre-existing unused-var warning at line 120 confirmed present on `develop` base too, unrelated to this change)
- [x] `npx prettier --check prices/prices.service.ts` — passes
- [ ] Post-deploy: confirm `Cannot read properties of undefined (reading 'eur')` drops to 0 on `deuro-deuro-api-9`