### PR TITLE
fix: attribute network errors to the URL the request was sent to

### DIFF
--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -9,18 +9,27 @@ const logger = new Logger('ApiApolloConfig');
 const FALLBACK_WINDOW_MS = 10 * 60 * 1000;
 let fallbackUntil: number | null = null;
 
+function isFallbackActive(): boolean {
+	return fallbackUntil !== null && Date.now() < fallbackUntil;
+}
+
 function getIndexerUrl(): string {
-	return fallbackUntil && Date.now() < fallbackUntil ? CONFIG.indexerFallback : CONFIG.indexer;
+	return isFallbackActive() ? CONFIG.indexerFallback : CONFIG.indexer;
 }
 
 function activateFallback(): void {
-	// Re-arm when the previous window has expired so a sustained outage
-	// keeps the fallback engaged instead of silently flipping back to primary.
-	if ((!fallbackUntil || Date.now() >= fallbackUntil) && CONFIG.indexerFallback) {
+	if (!isFallbackActive() && CONFIG.indexerFallback) {
 		fallbackUntil = Date.now() + FALLBACK_WINDOW_MS;
-		logger.log(`[Ponder] Switching to fallback for 10min: ${CONFIG.indexerFallback}`);
+		logger.warn(`[Ponder] Switching to fallback for ${FALLBACK_WINDOW_MS / 60000}min: ${CONFIG.indexerFallback}`);
 	}
 }
+
+// Stamps each attempt with its target URL so errors are attributed to the URL
+// the request was actually sent to, not the routing state at error time.
+const routingLink = new ApolloLink((operation, forward) => {
+	operation.setContext({ targetUrl: getIndexerUrl() });
+	return forward(operation);
+});
 
 const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
 	const opName = operation?.operationName || 'unknown';
@@ -32,26 +41,24 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 	}
 
 	if (networkError) {
-		const hasFallback = !!CONFIG.indexerFallback;
-		const onFallback = getIndexerUrl() !== CONFIG.indexer;
-		const willRecover = hasFallback && !onFallback;
 		const msg = `[Network error in operation: ${opName}] ${networkError.message}`;
+		const sentToFallback = !!CONFIG.indexerFallback && operation.getContext().targetUrl === CONFIG.indexerFallback;
 
-		if (willRecover) {
-			// Primary failed, fallback hasn't been engaged this window — log
-			// at warn so transparent retries don't inflate error-rate panels.
+		if (CONFIG.indexerFallback && !sentToFallback) {
+			// Primary failed and a fallback exists — log at warn so transparent
+			// retries don't inflate error-rate panels.
 			logger.warn(msg);
 			activateFallback();
 			return forward(operation);
 		}
 
-		// No fallback configured, or already on fallback — nothing more to try.
+		// No fallback configured, or the fallback itself failed — nothing more to try.
 		logger.error(msg);
 	}
 });
 
 const httpLink = createHttpLink({
-	uri: () => getIndexerUrl(),
+	uri: (operation) => operation.getContext().targetUrl ?? getIndexerUrl(),
 	fetch: (uri: RequestInfo | URL, options?: RequestInit) => {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => {
@@ -67,7 +74,7 @@ const httpLink = createHttpLink({
 	},
 });
 
-const link = ApolloLink.from([errorLink, httpLink]);
+const link = ApolloLink.from([errorLink, routingLink, httpLink]);
 
 export const PONDER_CLIENT = new ApolloClient({
 	link,


### PR DESCRIPTION
## Summary

Follow-up to #117, ported from [`JuiceDollar/api#58`](https://github.com/JuiceDollar/api/pull/58) per the shared-codebase convention — both `api.apollo.config.ts` files are byte-identical again after this change.

A review of the sibling PR surfaced three issues in the merged #117 logic, all rooted in deriving fallback state from current routing state instead of the URL the failed request was actually sent to:

1. **Dead-fallback pinning.** A request sent to the fallback whose error arrives just after `fallbackUntil` expires was misread as a primary failure: it re-armed the window and pinned all traffic to the (dead) fallback for another 10 minutes while the primary was healthy.
2. **Same-URL config hides severity.** If `CONFIG_INDEXER_FALLBACK_URL` equals the primary URL, every network error took the warn+retry branch forever — a sustained outage produced zero error-level logs.
3. **Fallback switch invisible in prod.** The only line recording a switch was `logger.log` (info), which `LOG_LEVEL=warn` filters out.

## Change

- New `routingLink` stamps each attempt with its target URL on the operation context; the error handler and `httpLink`'s `uri` both read the stamp. Retries re-enter the link, so they naturally route to the freshly armed fallback.
- Retry/severity decision keys on `sentToFallback` (the attempted URL), fixing 1 and 2: fallback-sent failures always log at error with no retry, and `fallback === primary` no longer downgrades severity.
- Fallback-switch breadcrumb raised to `warn` (fixes 3) and its duration derived from `FALLBACK_WINDOW_MS`.
- Window-active checks consolidated into one `isFallbackActive()` predicate.

## Verification

- `yarn build` and `npx prettier --check api.apollo.config.ts` clean on the branch.
- Exercised the built client against unreachable endpoints in three configs:
  - distinct fallback: warn on primary failure + warn switch line, retry genuinely hits the fallback URL; in-window fallback failures log at error, no retry
  - `fallback === primary`: error severity retained, no retry
  - no fallback: error, propagates (unchanged)

Known residual (structural to Apollo's `onError`, unchanged): the retry's own failure never re-enters the handler, so the first operation of a window whose fallback attempt also fails surfaces to the caller with only warn-level lines. The warn-level switch breadcrumb plus error-level in-window failures keep such an outage visible.