### PR TITLE
fix: track Ponder fallback routing as a flag, not a URL comparison

### DIFF
--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -24,10 +24,14 @@ function activateFallback(): void {
 	}
 }
 
-// Stamps each attempt with its target URL so errors are attributed to the URL
-// the request was actually sent to, not the routing state at error time.
+// Stamps each attempt with the URL it was sent to and whether that was the
+// fallback, so errors are attributed to the routing state at SEND time, not
+// re-derived from the URL at error time — a bare URL comparison can't tell
+// primary from fallback once an operator points the fallback at the same
+// host as the primary (the standard way to disable cross-environment
+// failover; see CONFIG_INDEXER_FALLBACK_URL in the prd/dev compose files).
 const routingLink = new ApolloLink((operation, forward) => {
-	operation.setContext({ targetUrl: getIndexerUrl() });
+	operation.setContext({ targetUrl: getIndexerUrl(), usedFallback: isFallbackActive() });
 	return forward(operation);
 });
 
@@ -42,7 +46,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 
 	if (networkError) {
 		const msg = `[Network error in operation: ${opName}] ${networkError.message}`;
-		const sentToFallback = !!CONFIG.indexerFallback && operation.getContext().targetUrl === CONFIG.indexerFallback;
+		const sentToFallback = !!operation.getContext().usedFallback;
 
 		if (CONFIG.indexerFallback && !sentToFallback) {
 			// Primary failed and a fallback exists — log at warn so transparent

--- a/api.apollo.config.ts
+++ b/api.apollo.config.ts
@@ -29,7 +29,7 @@ function activateFallback(): void {
 // re-derived from the URL at error time — a bare URL comparison can't tell
 // primary from fallback once an operator points the fallback at the same
 // host as the primary (the standard way to disable cross-environment
-// failover; see CONFIG_INDEXER_FALLBACK_URL in the prd/dev compose files).
+// failover; see CONFIG_INDEXER_FALLBACK_URL in this repo's own deploy config).
 const routingLink = new ApolloLink((operation, forward) => {
 	operation.setContext({ targetUrl: getIndexerUrl(), usedFallback: isFallbackActive() });
 	return forward(operation);


### PR DESCRIPTION
## Summary
- `errorLink` decides whether a failed Ponder request already went to the fallback by comparing `operation.getContext().targetUrl` against `CONFIG.indexerFallback` as strings.
- Our prd/dev compose files set `CONFIG_INDEXER_FALLBACK_URL` to the **same value** as `CONFIG_INDEXER_URL` (documented in the compose comment — the only way to keep the var populated without leaking prd traffic onto dev). With primary and fallback string-identical, `targetUrl === CONFIG.indexerFallback` is true on every request regardless of which URL it actually went to, so the `warn` + retry branch (lines 47-52) can never execute — every network error still falls through to `logger.error`.
- Confirmed live in Grafana/Loki: the last 30 `ApiApolloConfig` network-error lines in prod were **all** `error`, none `warn`, despite this fallback mechanism (#117 / #121) having been deployed since 2026-07-20.
- Fix: `routingLink` now stamps `usedFallback: isFallbackActive()` at send time, and `errorLink` reads that flag instead of re-deriving it from a URL comparison. This correctly distinguishes primary vs. fallback attempts even when they resolve to the same URL string.

## Test plan
- [x] Reviewed against the existing retry path: on retry, `routingLink` re-stamps context from the (now fallback-active) state, so a second failure against the fallback correctly falls through to `error` — behavior unchanged from the intended design, just no longer defeated by same-URL configs.
- [ ] After merge: watch Loki for `ApiApolloConfig` network-error lines to move from `error` to `warn` on the next transient Ponder blip.